### PR TITLE
[W02H02] Add test for 0 net profit

### DIFF
--- a/w02h02/test/pgdp/CasinoTest.java
+++ b/w02h02/test/pgdp/CasinoTest.java
@@ -140,40 +140,6 @@ public class CasinoTest {
                 """
                         Welcome to Pengu-BlackJack!
                         (1) Start a game or (2) exit
-                        IN: 1
-                        Your current balance: 1000
-                        How much do you want to bet?
-                        IN: 10
-                        Player cards:
-                        1 : 2
-                        2 : 10
-                        Current standing: 12
-                        (1) draw another card or (2) stay
-                        IN: 2
-                        Dealer cards:
-                        1 : 6
-                        2 : 1
-                        3 : 5
-                        4 : 11
-                        Dealer: 23
-                        You won 10 tokens.
-                        (1) Start a game or (2) exit
-                        IN: 1
-                        Your current balance: 1010
-                        How much do you want to bet?
-                        IN: 10
-                        Player cards:
-                        1 : 5
-                        2 : 5
-                        Current standing: 10
-                        (1) draw another card or (2) stay
-                        IN: 2
-                        Dealer cards:
-                        1 : 8
-                        2 : 11
-                        Dealer: 19
-                        Dealer wins. You lost 10 tokens.
-                        (1) Start a game or (2) exit
                         IN: 2
                         Your final balance: 1000
                         That's very very sad :(

--- a/w02h02/test/pgdp/CasinoTest.java
+++ b/w02h02/test/pgdp/CasinoTest.java
@@ -133,6 +133,55 @@ public class CasinoTest {
     }
 
     @Test
+    @DisplayName("Player should lose when net profit is 0")
+    void check0Profi() {
+        testBlackjackOutput(
+                10,
+                """
+                        Welcome to Pengu-BlackJack!
+                        (1) Start a game or (2) exit
+                        IN: 1
+                        Your current balance: 1000
+                        How much do you want to bet?
+                        IN: 10
+                        Player cards:
+                        1 : 2
+                        2 : 10
+                        Current standing: 12
+                        (1) draw another card or (2) stay
+                        IN: 2
+                        Dealer cards:
+                        1 : 6
+                        2 : 1
+                        3 : 5
+                        4 : 11
+                        Dealer: 23
+                        You won 10 tokens.
+                        (1) Start a game or (2) exit
+                        IN: 1
+                        Your current balance: 1010
+                        How much do you want to bet?
+                        IN: 10
+                        Player cards:
+                        1 : 5
+                        2 : 5
+                        Current standing: 10
+                        (1) draw another card or (2) stay
+                        IN: 2
+                        Dealer cards:
+                        1 : 8
+                        2 : 11
+                        Dealer: 19
+                        Dealer wins. You lost 10 tokens.
+                        (1) Start a game or (2) exit
+                        IN: 2
+                        Your final balance: 1000
+                        That's very very sad :(
+                        Thank you for playing. See you next time.
+                        """);
+    }
+
+    @Test
     @DisplayName("No tokens left")
     void broke() {
         testBlackjackOutput(


### PR DESCRIPTION
Adding a test that verifies that you display the lose message when the user has a net profit of 0 (e.g. first round winning 10 tokens, second round losing 10 tokens) because 0 is not "echter positiver Gewinn" (see task).

cc: @simonsmd 