### PR TITLE
[w04h02] more tests

### DIFF
--- a/w04h02/test/pgdp/megamerge/MegaMergeSortTest.java
+++ b/w04h02/test/pgdp/megamerge/MegaMergeSortTest.java
@@ -1,0 +1,145 @@
+package pgdp.megamerge;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class MegaMergeSortTest {
+    @ParameterizedTest
+    @DisplayName("Correct sorting")
+    @MethodSource
+    void correctSorting(int[] a, int div, int[] result) {
+        assertArrayEquals(result, (new MegaMergeSort()).megaMergeSort(a, div));
+    }
+
+    private static ArrayList<Arguments> correctSorting() {
+        int[][] arrays = new int[][]{
+                {7, 6, 1, 2, 5, 9, 3, 4, 8},
+                {8, -6, 3, Integer.MAX_VALUE, Integer.MIN_VALUE, 2, 8, 0, -10, 11, 0},
+                {1, 8, 6, -3, 7, -89, 784632, Integer.MIN_VALUE, 0, 0, 0, -1, 69, 2, 12345, -1}
+        };
+
+        ArrayList<Arguments> inputs = new ArrayList<>();
+
+        for (int[] a : arrays) {
+            int[] result = Arrays.copyOf(a, a.length);
+            Arrays.sort(result);
+            for (int i = 2; i <= a.length; i++) {
+                inputs.add(arguments(a, i, result));
+            }
+            inputs.add(arguments(a, 1000, result));
+        }
+
+        return inputs;
+    }
+
+    @Test
+    @DisplayName("Empty range")
+    void emptyRange() {
+        assertArrayEquals(new int[0], (new MegaMergeSort()).megaMergeSort(new int[10], 2, 5, 5));
+    }
+
+    @Test
+    @DisplayName("Empty array")
+    void emptyArray() {
+        assertArrayEquals(new int[0], (new MegaMergeSort()).megaMergeSort(new int[0], 5));
+    }
+
+    @ParameterizedTest
+    @DisplayName("Array split")
+    @MethodSource
+    void arraySplit(int[] a, int div, int[][] expectedSplit) {
+        SortWrapper wrapper = new SortWrapper();
+        int[][] actualSplit = wrapper.megaMergeSortSplit(a, div);
+
+        if (!Arrays.deepEquals(expectedSplit, actualSplit)) {
+            String msg = "Incorrect split!\n" +
+                    "Expected:\t" + Arrays.deepToString(expectedSplit) +
+                    "\nActual:\t\t" + Arrays.deepToString(actualSplit);
+            fail(msg);
+        }
+    }
+
+    private static Stream<Arguments> arraySplit() {
+        return Stream.of(
+                arguments(
+                        new int[]{1, 2, 3, 4, 5, 6, 7, 8},
+                        3,
+                        new int[][]{
+                                {1, 2, 3},
+                                {4, 5, 6},
+                                {7, 8}
+                        }
+                ),
+                arguments(
+                        new int[]{1, 2, 3},
+                        3,
+                        new int[][]{
+                                {1},
+                                {2},
+                                {3}
+                        }
+                ),
+                arguments(
+                        new int[]{7, 8},
+                        3,
+                        new int[][]{
+                                {7},
+                                {8},
+                                {}
+                        }
+                ),
+                arguments(
+                        new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+                        3,
+                        new int[][]{
+                                {1, 2, 3, 4},
+                                {5, 6, 7},
+                                {8, 9, 10}
+                        }
+                ),
+                arguments(
+                        new int[]{1, 2},
+                        5,
+                        new int[][]{
+                                {1},
+                                {2},
+                                {},
+                                {},
+                                {}
+                        }
+                )
+        );
+    }
+}
+
+class SortWrapper extends MegaMergeSort {
+    private final ArrayList<int[]> split = new ArrayList<>();
+
+    @Override
+    protected int[] megaMergeSort(int[] array, int div, int from, int to) {
+        int[] result = super.megaMergeSort(array, div, from, to);
+
+        // I can't think of a better way to check if this is the second level of recursion
+        if (Thread.currentThread().getStackTrace()[3].getMethodName().equals("megaMergeSortSplit")) {
+            split.add(result);
+        }
+
+        return result;
+    }
+
+    public int[][] megaMergeSortSplit(int[] array, int div) {
+        super.megaMergeSort(array, div, 0, array.length);
+        return split.toArray(new int[0][]);
+    }
+}

--- a/w04h02/test/pgdp/megamerge/MergeRecursiveTest.java
+++ b/w04h02/test/pgdp/megamerge/MergeRecursiveTest.java
@@ -1,0 +1,220 @@
+package pgdp.megamerge;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class MergeRecursiveTest {
+    @ParameterizedTest
+    @DisplayName("Merge arrays")
+    @MethodSource
+    void mergeArrays(int[][] arrays, int from, int to, int[] result) {
+        assertArrayEquals(result, (new MegaMergeSort()).merge(arrays, from, to));
+    }
+
+    private static Stream<Arguments> mergeArrays() {
+        return Stream.of(
+                arguments(
+                        new int[][]{
+                                {1},
+                                {2},
+                                {3},
+                                {4}
+                        },
+                        0,
+                        4,
+                        new int[]{1, 2, 3, 4}
+                ),
+                arguments(
+                        new int[][]{
+                                {3, 5},
+                                {Integer.MAX_VALUE},
+                                {-3, 8, 12},
+                                {Integer.MIN_VALUE, Integer.MAX_VALUE},
+                                {7, 11},
+                                {Integer.MIN_VALUE},
+                                {-1, 0, 5}
+                        },
+                        0,
+                        7,
+                        new int[]{
+                                Integer.MIN_VALUE, Integer.MIN_VALUE,
+                                -3, -1, 0, 3, 5, 5, 7, 8, 11, 12,
+                                Integer.MAX_VALUE, Integer.MAX_VALUE
+                        }
+                ),
+                arguments(
+                        new int[][]{
+                                {-7, 3, 10},
+                                {0, 0, 0},
+                                {2, 5, 6},
+                                {1, 2, 3},
+                                {120, 121},
+                                {-1, 1},
+                                {-5, 10, 15},
+                                {2}
+                        },
+                        1,
+                        5,
+                        new int[]{0, 0, 0, 1, 2, 2, 3, 5, 6, 120, 121}
+                ),
+                arguments(
+                        new int[][]{
+                                {0},
+                                {1, 2},
+                                {3, 4},
+                                {0}
+                        },
+                        1,
+                        2,
+                        new int[]{1, 2}
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("Empty range")
+    void emptyRange() {
+        assertArrayEquals(new int[0], (new MegaMergeSort()).merge(new int[10][10], 5, 5));
+    }
+
+    @ParameterizedTest
+    @DisplayName("Empty arrays")
+    @MethodSource
+    void emptyArrays(int[][] array, int[] result) {
+        assertArrayEquals(result, (new MegaMergeSort()).merge(array, 0, array.length));
+    }
+
+    private static Stream<Arguments> emptyArrays(){
+        return Stream.of(
+                arguments(
+                        new int[10][0],
+                        new int[0]
+                ),
+                arguments(
+                        new int[0][10],
+                        new int[0]
+                ),
+                arguments(
+                        new int[][]{
+                                {},
+                                {3, 5},
+                                {},
+                                {},
+                                {1},
+                                {},
+                                {2, 4},
+                                {}
+                        },
+                        new int[]{1, 2, 3, 4, 5}
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("Merge order")
+    @MethodSource
+    void mergeOrder(int[][] array, int from, int to, int[][] expectedMergeSteps) {
+        MergeWrapper wrapper = new MergeWrapper();
+        wrapper.merge(array, from, to);
+
+        int[][] mergeSteps = wrapper.mergeSteps();
+        int j = 0;
+
+        for (int i = 0; i < mergeSteps.length; i++) {
+            if (j == expectedMergeSteps.length) {
+                failMergeOrder(mergeSteps, expectedMergeSteps, "More merge steps than expected!");
+            }
+
+            if (Arrays.equals(mergeSteps[i], expectedMergeSteps[j])) {
+                j++;
+            } else {
+                if (j > 0) {
+                    failMergeOrder(mergeSteps, expectedMergeSteps, "Incorrect merge step(s)!");
+                }
+            }
+        }
+
+        if (j != expectedMergeSteps.length) {
+            failMergeOrder(mergeSteps, expectedMergeSteps, "Missing merge step(s)!");
+        }
+    }
+
+    private static void failMergeOrder(int[][] actual, int[][] expected, String msg) {
+        msg += "\nExpected merge steps:\t" + Arrays.deepToString(expected) +
+                "\nActual merge steps:\t\t" + Arrays.deepToString(actual);
+        fail(msg);
+    }
+
+    private static Stream<Arguments> mergeOrder() {
+        return Stream.of(
+                arguments(
+                        new int[][]{
+                                {1},
+                                {2},
+                                {3},
+                                {4}
+                        },
+                        0,
+                        4,
+                        new int[][]{
+                                {3, 4},
+                                {2, 3, 4},
+                                {1, 2, 3, 4}
+                        }
+                ),
+                arguments(
+                        new int[][]{
+                                {-7, 3, 10},
+                                {0, 0, 0},
+                                {2, 5, 6},
+                                {1, 2, 3},
+                                {120, 121},
+                                {-1, 1},
+                                {-5, 10, 15}
+                        },
+                        1,
+                        5,
+                        new int[][]{
+                                {1, 2, 3, 120, 121},
+                                {1, 2, 2, 3, 5, 6, 120, 121},
+                                {0, 0, 0, 1, 2, 2, 3, 5, 6, 120, 121}
+                        }
+                ),
+                arguments(
+                        new int[][]{
+                                {1}
+                        },
+                        0,
+                        1,
+                        new int[][]{
+                                {1}
+                        }
+                )
+        );
+    }
+}
+
+class MergeWrapper extends MegaMergeSort {
+    private final ArrayList<int[]> mergeSteps = new ArrayList<>();
+
+    @Override
+    protected int[] merge(int[][] arrays, int from, int to) {
+        int[] result = super.merge(arrays, from, to);
+        mergeSteps.add(result);
+        return result;
+    }
+
+    public int[][] mergeSteps() {
+        return mergeSteps.toArray(new int[0][]);
+    }
+}

--- a/w04h02/test/pgdp/megamerge/MergeTest.java
+++ b/w04h02/test/pgdp/megamerge/MergeTest.java
@@ -1,0 +1,99 @@
+package pgdp.megamerge;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class MergeTest {
+    @ParameterizedTest
+    @DisplayName("Arrays with equal length")
+    @MethodSource
+    void equalLengthArrays(int[] a, int[] b, int[] result) {
+        assertArrayEquals(result, (new MegaMergeSort()).merge(a, b));
+    }
+
+    private static Stream<Arguments> equalLengthArrays() {
+        return Stream.of(
+                arguments(
+                        new int[]{1, 3},
+                        new int[]{2, 4},
+                        new int[]{1, 2, 3, 4}
+                ),
+                arguments(
+                        new int[]{-2, 5, 10},
+                        new int[]{-3, 0, 1},
+                        new int[]{-3, -2, 0, 1, 5, 10}
+                ),
+                arguments(
+                        new int[]{Integer.MIN_VALUE, 15, Integer.MAX_VALUE},
+                        new int[]{Integer.MIN_VALUE, Integer.MIN_VALUE, 10},
+                        new int[]{Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, 10, 15, Integer.MAX_VALUE}
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("Arrays with different lengths")
+    @MethodSource
+    void differentLengthArrays(int[] a, int[] b, int[] result) {
+        assertArrayEquals(result, (new MegaMergeSort()).merge(a, b));
+    }
+
+    private static Stream<Arguments> differentLengthArrays() {
+        return Stream.of(
+                arguments(
+                        new int[]{0, 0, 0, 0, 0},
+                        new int[]{1, 2, 3},
+                        new int[]{0, 0, 0, 0, 0, 1, 2, 3}
+                ),
+                arguments(
+                        new int[]{1, 2, 4, 5},
+                        new int[]{3},
+                        new int[]{1, 2, 3, 4, 5}
+                ),
+                arguments(
+                        new int[]{Integer.MIN_VALUE},
+                        new int[]{Integer.MAX_VALUE, Integer.MAX_VALUE},
+                        new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE}
+                ),
+                arguments(
+                        new int[]{-4, -3, 1},
+                        new int[]{5},
+                        new int[]{-4, -3, 1, 5}
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("Empty arrays")
+    @MethodSource
+    void emptyArrays(int[] a, int[] b, int[] result) {
+        assertArrayEquals(result, (new MegaMergeSort()).merge(a, b));
+    }
+
+    private static Stream<Arguments> emptyArrays() {
+        return Stream.of(
+                arguments(
+                        new int[0],
+                        new int[0],
+                        new int[0]
+                ),
+                arguments(
+                        new int[0],
+                        new int[]{0, 1, 2},
+                        new int[]{0, 1, 2}
+                ),
+                arguments(
+                        new int[]{0},
+                        new int[0],
+                        new int[]{0}
+                )
+        );
+    }
+}

--- a/w04h02/test/pgdp/megamerge/UnitTests.java
+++ b/w04h02/test/pgdp/megamerge/UnitTests.java
@@ -1,4 +1,4 @@
-package pgdp;
+package pgdp.megamerge;
 
 import jdk.jfr.Name;
 import org.junit.jupiter.api.*;


### PR DESCRIPTION
The task description for the recursive `merge` method does not specify whether the merge steps as shown in the example must be _**contained**_ in the solution or if _**only**_ those merge steps are allowed. The current implementation of the test ignores all merge steps preceding the expected ones.
For the example array from Artemis `[[1], [2], [3], [4]]` the test allows both of the following variants because they both contain the merge steps from the example.
```
[[], [4], [4, 3], [4, 3, 2], [4, 3, 2, 1]]
[[4, 3], [4, 3, 2], [4, 3, 2, 1]]
```