### PR TITLE
[W03H03] Add corner case test in build_seams_Seamsarray

### DIFF
--- a/w03h03/test/pgdp/SeamCarvingTest.java
+++ b/w03h03/test/pgdp/SeamCarvingTest.java
@@ -158,20 +158,43 @@ public class SeamCarvingTest {
 
         static Stream<Arguments> testing_build_seams_seamsArray() {
             return Stream.of(
-                    arguments(
-                            new int[6][5],
-                            new long[6],
-                            new int[]{
-                                    Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE,
-                                    1, 1, 1, 1, 1, 1,
-                                    69, 420, 42, 42, 42, 1337,
-                                    100, 10, 666, 20, 3, 10,
-                                    Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE
-                            },
-                            6,
-                            5,
-                            new int[][]{new int[]{0, 0, 0, 1, 1}, new int[]{1, 1, 2, 1, 1}, new int[]{2, 2, 2, 1, 1}, new int[]{3, 3, 3, 4, 4}, new int[]{4, 4, 4, 4, 4}, new int[]{5, 5, 4, 4, 4}}
-                    )
+                arguments(
+                    new int[6][5],
+                    new long[6],
+                    new int[] {
+                        Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE,
+                        Integer.MAX_VALUE,
+                        1, 1, 1, 1, 1, 1,
+                        69, 420, 42, 42, 42, 1337,
+                        100, 10, 666, 20, 3, 10,
+                        Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE,
+                        Integer.MAX_VALUE
+                    },
+                    6,
+                    5,
+                    new int[][] {
+                        {0, 0, 0, 1, 1},
+                        {1, 1, 2, 1, 1},
+                        {2, 2, 2, 1, 1},
+                        {3, 3, 3, 4, 4},
+                        {4, 4, 4, 4, 4},
+                        {5, 5, 4, 4, 4}
+                    }
+                ),
+                arguments(
+                    new int[2][2],
+                    new long[2],
+                    new int[] {
+                        Integer.MAX_VALUE, Integer.MAX_VALUE,
+                        Integer.MAX_VALUE, Integer.MAX_VALUE,
+                    },
+                    2,
+                    2,
+                    new int[][] {
+                        {0, 0},
+                        {1, 1}
+                    }
+                )
             );
         }
 


### PR DESCRIPTION
<!-- Danke, dass du deine Tests mit deinen Kommilitonen teilst. -->
<!-- Beschreibe doch kurz hier drin, was deine Tests überprüfen und ob du dir eventuell bei etwas unsicher bist. -->
<!-- Denk dran, dass deine Kommilitonen auch schon die Tests sehen, bevor dieser PR gemergt wird, pass also auf, was du an Code pusht! 
-->

<!-- Bitte nutzte ebenfalls als Prefix für den Titel der Pull Request die Woche und die Nr. der Hausaufgabe, z.B "[W02H02] Deinen Titel" -->

feat(w03h03/test/pgdp/SeamCarvingTest.java): 

Hey, ich hab kurz an folgenden Corner Case gedacht: 
welcher Pixel ist aus der nächsten Zeile zu bevorzugen, wenn man sich gegenwärtig am ganz rechten Rand einer Zeile befindet und in der unteren Zeile die beiden rechtesten Zahlen gleich sind?

Z.B. hier, von der 10 in der ersten Zeile: soll die linke oder die rechte 5 gewählt werden?

| Rest von links  | Vorletzt | Letzt |
| ------------- | ------------- | - |
| ... | _ | 10 |
| ... | 5 | 5 |

Was hier passieren soll, wird mir aus der Aufgabe aber nicht ganz klar. Da steht ja, dass bei gleichen Zahlen "links" und "rechts" immer die linke gewählt werden soll, dagegen aber auch immer "die mittlere", wenn sie unter den niedrigsten ist... welche unter zwei Zahlen die mittlere ist, ist nicht ganz klar 😄 

Ich würde mal sagen, der Seam strebt immer optimal "nur gerade nach unten" zu verlaufen, daher hab ich auch den test so geschrieben. Alles andere passt mit dieser Implementation. Was denkt ihr?