### PR TITLE
[*] Add check for pr title

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,6 @@
 <!-- Denk dran, dass deine Kommilitonen auch schon die Tests sehen, bevor dieser PR gemergt wird, pass also auf, was du an Code pusht! 
 -->
 
-<!-- Bitte nutzte ebenfalls als Prefix für den Titel der Pull Request die Woche und die Nr. der Hausaufgabe, z.B "[W02H02] Deinen Titel". Ebenfalls bitten wir dich darum, dass du nur an einer Hausaufgabe pro Pull Request Änderungen vornimmst. Solltest du Änderungen in mehreren Hausaufgaben vergenommen haben, spalte bitte diese Änderungen in mehrere Pull Requests auf. -->
+<!-- Bitte nutzte ebenfalls als Prefix für den Titel der Pull Request die Woche und die Nr. der Hausaufgabe, z.B "[W02H02] Deinen Titel". Solltest an keiner Hausaufgabe eine Änderung genommen haben, nutze stattdessen [*] als Prefix.
+
+Ebenfalls bitten wir dich darum, dass du nur an einer Hausaufgabe pro Pull Request Änderungen vornimmst. Solltest du Änderungen in mehreren Hausaufgaben vorgenommen haben, spalte bitte diese Änderungen in mehrere Pull Requests auf. -->

--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: Slashgear/action-check-pr-title@3.0.0
+      - uses: Slashgear/action-check-pr-title@v3.0.0
         with:
           regex: '^(\[W[0-9]{2}H[0-9]{2}\][ ]|\[\*\][ ])'

--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - uses: Slashgear/action-check-pr-title@v3.0.0
         with:
-          regexp: '^(\[W[0-9]{2}H[0-9]{2}\][ ]|\[\*\][ ])'
+          regexp: '^(\[W[0-9]{2}H0[0-9]\][ ]|\[\*\][ ])'

--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - uses: Slashgear/action-check-pr-title@v3.0.0
         with:
-          regexp: '^(\[W[0-9]{2}H0[0-9]\][ ]|\[\*\][ ])'
+          regexp: '^(\[W[0-9]{2}H0[1-3]\][ ]|\[\*\][ ])'

--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: Slashgear/action-check-pr-title@2.0.0
+      - uses: Slashgear/action-check-pr-title@3.0.0
         with:
           regex: '^(\[W[0-9]{2}H[0-9]{2}\][ ]|\[\*\][ ])'

--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -1,0 +1,20 @@
+name: validate-pr-title
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+
+jobs:
+  # This workflow applies validates the PR.
+  #
+  # Valid PR titles should start with [W00H00], e.g. [W03H03]. Use the name of
+  # the homework for that you make a change. If you don't change a homework
+  # (e.g. making changes to the pull request template in .github), use [*] as
+  # prefix.
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: Slashgear/action-check-pr-title@2.0.0
+        with:
+          regex: '^(\[W[0-9]{2}H[0-9]{2}\][ ]|\[\*\][ ])'

--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - uses: Slashgear/action-check-pr-title@v3.0.0
         with:
-          regex: '^(\[W[0-9]{2}H[0-9]{2}\][ ]|\[\*\][ ])'
+          regexp: '^(\[W[0-9]{2}H[0-9]{2}\][ ]|\[\*\][ ])'


### PR DESCRIPTION
This PR adds a check to validate PR titles should start with [W00H00], e.g. [W03H03]. Contributors should use the name of the homework for which they made a change. If they haven't changed a homework (e.g. making changes to the pull request template in .github), they should use [*] as prefix (like in this PR).

The homework number must be H01, H02 or H03.