### PR TITLE
[W04H02] Add test for edge cases of `.merge(int[][] arrays, int from, int to)`

### DIFF
--- a/w04h02/test/pgdp/megamerge/MergeTest.java
+++ b/w04h02/test/pgdp/megamerge/MergeTest.java
@@ -1,6 +1,7 @@
 package pgdp.megamerge;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -95,5 +96,88 @@ public class MergeTest {
                         new int[]{0}
                 )
         );
+    }
+
+    // Source: https://zulip.in.tum.de/#narrow/stream/1450-PGdP-W04H02/topic/to.20.3C.20from
+    @DisplayName(".merge(int[][] arrays, int from, int to) should handle negativ from values")
+    @Test
+    void testNegativeFromValues() {
+        int[][] arrays = new int[][]{
+                new int[]{5},
+                new int[]{6},
+                new int[]{7},
+        };
+
+        int[] mergedArray = new MegaMergeSort().merge(arrays, -2, 2);
+        
+        // arrays[0] and arrays[1] are in the range of -2 and 2. 
+        assertArrayEquals(mergedArray, new int[] { 5, 6 });
+    }
+
+    // Source: https://zulip.in.tum.de/#narrow/stream/1450-PGdP-W04H02/topic/to.20.3C.20from
+    @DisplayName(".merge(int[][] arrays, int from, int to) should handle to values greater than the length of the arrays")
+    @Test
+    void testToValuesGreaterThanLength() {
+        int[][] arrays = new int[][]{
+            new int[]{5},
+            new int[]{6},
+            new int[]{7},
+       };
+       
+       int[] mergedArray = new MegaMergeSort().merge(arrays, 0, 5);
+       
+       // arrays[0], arrays[1] and arrays[2] are in the range of 0 and 5.
+       assertArrayEquals(mergedArray, new int[] { 5, 6, 7 });
+    }
+
+    // Source: https://zulip.in.tum.de/#narrow/stream/1450-PGdP-W04H02/topic/to.20.3C.20from
+    @DisplayName(".merge(int[][] arrays, int from, int to) should handle a negative range")
+    @Test
+    void testNegativeRange() {
+        int[][] arrays = new int[][]{
+            new int[]{5},
+            new int[]{6},
+            new int[]{7},
+       };
+       
+       int[] mergedArray = new MegaMergeSort().merge(arrays, -3, -1);
+       
+       // Nothings is in the range of -3 and -1. Therefore, the returned array
+       // should be empty.
+       assertArrayEquals(mergedArray, new int[] {});
+    }
+
+    // Source: https://zulip.in.tum.de/#narrow/stream/1450-PGdP-W04H02/topic/to.20.3C.20from
+    @DisplayName(".merge(int[][] arrays, int from, int to) should handle a range is out of bounds")
+    @Test
+    void testRangeOutside() {
+        int[][] arrays = new int[][]{
+            new int[]{5},
+            new int[]{6},
+            new int[]{7},
+       };
+       
+       int[] mergedArray = new MegaMergeSort().merge(arrays, 3, 5);
+       
+       // Nothings is in the range of 3 and 5. Therefore, the returned array
+       // should be empty.
+       assertArrayEquals(mergedArray, new int[] {});
+    }
+
+    // Source: https://zulip.in.tum.de/#narrow/stream/1450-PGdP-W04H02/topic/to.20.3C.20from
+    @DisplayName(".merge(int[][] arrays, int from, int to) should handle a range where from is greater than to")
+    @Test
+    void testToIsSmallerThanFrom() {
+        int[][] arrays = new int[][]{
+            new int[]{5},
+            new int[]{6},
+            new int[]{7},
+       };
+       
+       int[] mergedArray = new MegaMergeSort().merge(arrays, 2, 1);
+       
+       // Nothings is in the range of 2 and 1. Therefore, the returned array
+       // should be empty.
+       assertArrayEquals(mergedArray, new int[] {});
     }
 }


### PR DESCRIPTION
## Description

Theoretically, is it not possible to hit these edge cases, when you call `megaMergeSort()`. However, we learned from W03 that this is nothing you can depend on. All methods are `protected` which means they can be called from outside the class. Therefore, it's possible to call the method with "stupid" input.

This PR contains this edge cases:
* .merge(int[][] arrays, int from, int to) should handle negativ from values
* .merge(int[][] arrays, int from, int to) should handle to values greater than the length of the arrays
* .merge(int[][] arrays, int from, int to) should handle a negative range
* .merge(int[][] arrays, int from, int to) should handle a range is out of bounds
* .merge(int[][] arrays, int from, int to) should handle a range where from is greater than to

Source for this behavior: https://zulip.in.tum.de/#narrow/stream/1450-PGdP-W04H02/topic/to.20.3C.20from