### PR TITLE
[W05H02] New array length greater than the previous one

### DIFF
--- a/w05h03/test/pgdp/MessengerTests.java
+++ b/w05h03/test/pgdp/MessengerTests.java
@@ -130,7 +130,7 @@ public class MessengerTests {
     public void testUserArrayGetterSetter() {
         UserArray ua = new UserArray(3);
         User alice = new User(5, "Alice", null);
-        User[] output = {alice, null, alice, null};
+        User[] output = {alice, null, alice};
         Assertions.assertEquals(3, ua.getUsers().length, "Wrong size at start");
         ua.setUsers(output);
         Assertions.assertEquals(output, ua.getUsers(), "Wrong members after setting with setter");


### PR DESCRIPTION
The array lenght will always be the same as the length of current array in the UserArray.  https://zulip.in.tum.de/#narrow/stream/1467-PGdP-W05H03/topic/UserArray.20addUser

