### PR TITLE
[W05H03] Update ListBehaviourTest.java

### DIFF
--- a/w05h03/test/pgdp/messenger/test/ListBehaviourTest.java
+++ b/w05h03/test/pgdp/messenger/test/ListBehaviourTest.java
@@ -160,14 +160,18 @@ public class ListBehaviourTest {
         @DisplayName("Merge one list")
         void mergeOneList() {
             List orderedList1 = new List();
+            List orderedList2 = new List();
 
             orderedList1.add(messages[0]);
             orderedList1.add(messages[8]);
+            
+            orderedList2.add(messages[0]);
+            orderedList2.add(messages[8]);
 
             List megaMeredList = List.megaMerge(orderedList1);
 
             for(int i = 0; i < megaMeredList.size(); i++) {
-                Assertions.assertSame(orderedList1.getByIndex(i), megaMeredList.getByIndex(i), "Wrong order of the merged list");
+                Assertions.assertSame(orderedList2.getByIndex(i), megaMeredList.getByIndex(i), "Wrong order of the merged list");
             }
         }
 


### PR DESCRIPTION
This test can fail if the original list orderedList1 is edited during merge, which is allowed ("Was mit den Input-Listen passiert bleibt dir überlassen").
