### PR TITLE
[W05H02]Two new test-cases

### DIFF
--- a/w05h02/test/pgdp/pingunetwork/behavioral/PinguNetworkTest.java
+++ b/w05h02/test/pgdp/pingunetwork/behavioral/PinguNetworkTest.java
@@ -285,6 +285,20 @@ public class PinguNetworkTest {
         assertArrayEquals(bob_gang.getMembers(), new User[]{bob, alice});
         assertEquals(bob_gang.getOwner(), bob);
     }
+    
+    @Test
+    @DisplayName("Group - remove owner not part of group, and no user in group")
+    void testGroup5() {
+        User bob = new User("Bob", "i code stuff", pic4);
+        Group bob_gang = new Group("zulip-chat", "more recycling symbols than on most bottles", bob, new Picture("Bayern", new int[][]{{0, 0, 0}, {0, 1, 0}, {0, 0, 0}}));
+        User alice = new User("Alice", "lol", pic2);
+
+        bob_gang.removeUser(bob);
+
+        bob_gang.removeUser(alice);
+        assertArrayEquals(bob_gang.getMembers(), new User[]{});
+        assertEquals(bob_gang.getOwner(), null);
+    }
 
     @Test
     @DisplayName("Simulated interactions - 1")

--- a/w05h02/test/pgdp/pingunetwork/behavioral/PinguNetworkTest.java
+++ b/w05h02/test/pgdp/pingunetwork/behavioral/PinguNetworkTest.java
@@ -299,6 +299,25 @@ public class PinguNetworkTest {
         assertArrayEquals(bob_gang.getMembers(), new User[]{});
         assertEquals(bob_gang.getOwner(), null);
     }
+    
+    @Test
+    @DisplayName("Group - remove owner, members not empty afterwards, owner arbitrary pos.")
+    void testGroup6() {
+        User bob = new User("Bob", "i code stuff", pic2);
+        Group bob_gang = new Group("zulip-chat", "more recycling symbols than on most bottles", bob, new Picture("Bayern", new int[][]{{0, 0, 0}, {0, 1, 0}, {0, 0, 0}}));
+        User alice = new User("Alice", "lol", pic4);
+        User wonderland = new User("wonderland", "lol", pic3);
+
+        bob_gang.addUser(alice);
+        bob_gang.addUser(wonderland);
+        assertArrayEquals(bob_gang.getMembers(), new User[]{bob, alice, wonderland});
+
+        bob_gang.setOwner(alice);
+        assertEquals(bob_gang.getOwner(), alice);
+        bob_gang.removeUser(alice);
+
+        assertEquals(bob_gang.getOwner(), bob);
+    }
 
     @Test
     @DisplayName("Simulated interactions - 1")


### PR DESCRIPTION
1. Try to remove a user from a group, in case the group previously did not contain any members.
2. Create a group, set owner to second person, remove a third person, remove second person, check that first person is owner.