### PR TITLE
[W05H03] Added set null tests

### DIFF
--- a/w05h03/test/pgdp/messenger/behavior/PinguTalkTest.java
+++ b/w05h03/test/pgdp/messenger/behavior/PinguTalkTest.java
@@ -100,6 +100,14 @@ public class PinguTalkTest {
         final var deletedMember = pinguTalk.deleteMember(0);
         assertNull(deletedMember);
     }
+    
+    @Test
+    void setMembersToNullCheckDeleteMember() {
+        final var pinguTalk = new PinguTalk(0, 0);
+        pinguTalk.setMembers(null);
+        final var deletedMember = pinguTalk.deleteMember(0);
+        assertNull(deletedMember);
+    }
 
     @Test()
     void createNewTopic() {
@@ -187,6 +195,14 @@ public class PinguTalkTest {
     @Test
     void deleteTopicShouldReturnNullWhenTopicDoesNotExist() {
         final var pinguTalk = new PinguTalk(0, 0);
+        final var deletedTopic = pinguTalk.deleteTopic(0);
+        assertNull(deletedTopic);
+    }
+    
+    @Test
+    void setTopicsToNullTryCheckTopicDeletion() {
+        final var pinguTalk = new PinguTalk(0, 0);
+        pinguTalk.setTopics(null);
         final var deletedTopic = pinguTalk.deleteTopic(0);
         assertNull(deletedTopic);
     }

--- a/w05h03/test/pgdp/messenger/behavior/UserArrayTest.java
+++ b/w05h03/test/pgdp/messenger/behavior/UserArrayTest.java
@@ -129,5 +129,18 @@ public class UserArrayTest {
         final var deletedUser = userArray.deleteUser(2);
         assertNull(deletedUser);
     }
+    
+    @Test
+    void setUserArrToNullThenTryMethods() {
+        final var userArray = new UserArray(1);
+        final var user = TestUtils.getTestUser();
+        final var user1 = TestUtils.getTestUser();
+        userArray.setUsers(null);
+        userArray.addUser(user);
+        final var returned = userArray.deleteUser(user1.getId());
+        assertNull(returned);
+        final var size = userArray.size();
+        assertEquals(0, size);
+    }
 }
 


### PR DESCRIPTION
The setter methods of PinguTalk and UserArray do allow passing `null`, thus we need to make sure our code does not crash. Easy checks added, I think they should be a minimum protection needed.