### PR TITLE
[W06H01] Use RegExp instead of simple keyword search for `testUsageOfLoops`

### DIFF
--- a/w06h01/test/pgdp/LoopTest.java
+++ b/w06h01/test/pgdp/LoopTest.java
@@ -1,6 +1,6 @@
 package pgdp;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -27,8 +27,9 @@ public class LoopTest {
         String[] notAllowedRegExp = new String[] {
                 "for\s*[(]{1}",
                 "while\s*[(]{1}",
-                "Stream.of",
+                "Stream.of\\(",
                 "Stream<",
+                "Arrays.stream\\(",
         };
 
         for (String path : filePaths) {
@@ -46,7 +47,7 @@ public class LoopTest {
             for (String regExp : notAllowedRegExp) {
                 Pattern pattern = Pattern.compile(regExp);
                 Matcher matcher = pattern.matcher(filteredFile);
-                assertTrue(!matcher.find(),
+                assertFalse(matcher.find(),
                         "You are not allowed to use loops in your solution!");
             }
         }

--- a/w06h01/test/pgdp/LoopTest.java
+++ b/w06h01/test/pgdp/LoopTest.java
@@ -6,6 +6,8 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +24,12 @@ public class LoopTest {
                 "src/pgdp/datastructures/lists/RecIntListElement.java"
         };
 
-        String[] notAllowedKeywords = new String[] { "for", "while", "Stream" };
+        String[] notAllowedRegExp = new String[] {
+                "for\s*[(]{1}",
+                "while\s*[(]{1}",
+                "Stream.of",
+                "Stream<",
+        };
 
         for (String path : filePaths) {
             // Methods that are allowed to use loops
@@ -36,9 +43,11 @@ public class LoopTest {
             String filteredFile = removeMultipleMethods(file, allowedMethods);
 
             // Check if there are any loops
-            for (String keyword : notAllowedKeywords) {
-                assertTrue(!filteredFile.contains(keyword),
-                        "You are not allowed to use loops in your solution! Found a loop : " + keyword);
+            for (String regExp : notAllowedRegExp) {
+                Pattern pattern = Pattern.compile(regExp);
+                Matcher matcher = pattern.matcher(filteredFile);
+                assertTrue(!matcher.find(),
+                        "You are not allowed to use loops in your solution!");
             }
         }
     }


### PR DESCRIPTION
Using regular expression instead of a simple keyword search (suggested by @julian-hartl in https://github.com/MaximilianAnzinger/pgdp2223-tests/pull/114/files#r1035113758).