### PR TITLE
[W06H02] remove/fix tests expecting specific values in unused mem array

### DIFF
--- a/w06h02/test/pgdp/ds/MultiStackTest.java
+++ b/w06h02/test/pgdp/ds/MultiStackTest.java
@@ -76,7 +76,7 @@ public class MultiStackTest {
         stack.push(value);
         final var next = getNext(getHead());
         final var mem = getMem(next);
-        assertTrue(arrayContains(mem, value));
+        assertEquals(mem[0], value);
     }
 
     @Test
@@ -183,7 +183,7 @@ public class MultiStackTest {
         stack.push(200);
         assertEquals(head, getHead());
     }
-    
+
     @Test
     void topShouldReturnCorrectValues() {
         final var value = 10;
@@ -202,7 +202,7 @@ public class MultiStackTest {
 
         assertArrayEquals(array(value), getMem(getHead()));
         assertArrayEquals(array(value2, value3), getMem(getNext(getHead())));
-        assertArrayEquals(array(value4, 0, 0, 0), getMem(getNext(getNext(getHead()))));
+        assertEquals(value4, getMem(getNext(getNext(getHead())))[0]);
     }
 
 
@@ -227,7 +227,5 @@ public class MultiStackTest {
         assertEquals(value3, stack.pop());
         assertEquals(value4, stack.pop());
         assertEquals(value2, stack.pop());
-
-        assertArrayEquals(array(0), getMem(getHead()));
     }
 }

--- a/w06h02/test/pgdp/ds/MultiStackTest.java
+++ b/w06h02/test/pgdp/ds/MultiStackTest.java
@@ -227,5 +227,7 @@ public class MultiStackTest {
         assertEquals(value3, stack.pop());
         assertEquals(value4, stack.pop());
         assertEquals(value2, stack.pop());
+
+        assertEquals(Integer.MIN_VALUE, stack.pop());
     }
 }


### PR DESCRIPTION
The task description does not specify whether or not the mem array must get modified by `pop()` ([confirmed](https://zulip.in.tum.de/#narrow/stream/1480-PGdP-W06H02/topic/pop.28.29.20muss.20mem.20ver.C3.A4ndert.20werden.3F)).

This pr removes/fixes tests which assume that unused memory has to be filled with zeros. Closes #119 and closes #125