### PR TITLE
[W06H03] compare sorted list of adjacent nodes

### DIFF
--- a/w06h03/test/pgdp/ds/DenseGraphCapabilityTest.java
+++ b/w06h03/test/pgdp/ds/DenseGraphCapabilityTest.java
@@ -6,38 +6,45 @@ import org.junit.jupiter.api.Test;
 
 import pgdp.ds.DenseGraph;
 
+import java.util.Arrays;
+
 
 class DenseGraphCapabilityTest {
-      /**
-       * Laut Aufgabenstellung muss der Dense Graph "vllt. einige Zehntausend" Knoten, aber "von jedem Knoten aus Kanten
-       * zu einem großen Teil der anderen Knoten haben. Hier wird ein Graph generiert, der n Knoten hat, und eine Kante
-       * zwischen allen Knoten (inkl. Schleifen), damit also n² Kanten.
-       * Durch Anpassung des Parameters n kann jede beliebige Anzahl an Kanten getestet werden.
-       * Nach jedem Test wird stichprobenartig getestet, ob alle Nachbarn des Knotens mit der ID 0 korrekt gespeichert
-       * wurden.
-       **/
-      private int n = 60000;
+    /**
+     * Laut Aufgabenstellung muss der Dense Graph "vllt. einige Zehntausend" Knoten, aber "von jedem Knoten aus Kanten
+     * zu einem großen Teil der anderen Knoten haben. Hier wird ein Graph generiert, der n Knoten hat, und eine Kante
+     * zwischen allen Knoten (inkl. Schleifen), damit also n² Kanten.
+     * Durch Anpassung des Parameters n kann jede beliebige Anzahl an Kanten getestet werden.
+     * Nach jedem Test wird stichprobenartig getestet, ob alle Nachbarn des Knotens mit der ID 0 korrekt gespeichert
+     * wurden.
+     **/
+    private int n = 60000;
 
 
     @Test
     @DisplayName("Testing DenseGraph for specified amount of nodes")
     public void testDenseGraph() {
         System.out.println("Nodes: " + n);
-        System.out.println("Edges: " + ((long)n*(long)n));
+        System.out.println("Edges: " + ((long) n * (long) n));
         DenseGraph denseGraph = new DenseGraph(n);
-        for(int i = 0; i < n; i++){
-            for (int j = 0; j < n; j++){
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
                 denseGraph.addEdge(i, j);
             }
         }
-        long l = (Runtime.getRuntime().totalMemory()-Runtime.getRuntime().freeMemory()) / 1_000_000;
+        long l = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1_000_000;
         System.out.println("Used: " + l + "MB of RAM");
         int[] res = new int[n];
-        for (int i = 0; i < res.length; i++){
+        for (int i = 0; i < res.length; i++) {
             res[i] = i;
         }
-        Assertions.assertArrayEquals(res, denseGraph.getAdj(1));
 
+        int[] actual = denseGraph.getAdj(1);
+
+        Arrays.sort(res);
+        Arrays.sort(actual);
+
+        Assertions.assertArrayEquals(res, actual);
     }
 
 }

--- a/w06h03/test/pgdp/ds/SparseGraphCapabilityTest.java
+++ b/w06h03/test/pgdp/ds/SparseGraphCapabilityTest.java
@@ -27,19 +27,25 @@ class SparseGraphCapabilityTest {
         SparseGraph sparseGraph = new SparseGraph(nodes);
         System.out.println(sparseGraph.getNumberOfNodes());
 
-        for(int i = 0; i< nodes; i++){
-            for (int j = i; j < i+edgesPerNode; j++){
+        for (int i = 0; i < nodes; i++) {
+            for (int j = i; j < i + edgesPerNode; j++) {
                 sparseGraph.addEdge(i, j);
             }
         }
-        long l = (Runtime.getRuntime().totalMemory()-Runtime.getRuntime().freeMemory()) / 1_000_000;
+        long l = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1_000_000;
         System.out.println("Used: " + l + "MB of RAM");
         int[] res = new int[edgesPerNode];
-        for(int i = 0; i < edgesPerNode; i++){
+        for (int i = 0; i < edgesPerNode; i++) {
             int addRes = 420 + i;
             res[i] = addRes;
         }
-        Assertions.assertArrayEquals(res, sparseGraph.getAdj(420));
+
+        int[] actual = sparseGraph.getAdj(420);
+
+        Arrays.sort(res);
+        Arrays.sort(actual);
+
+        Assertions.assertArrayEquals(res, actual);
     }
 
 }


### PR DESCRIPTION
The task description does not specify a specific order. Therefore expected and actual have to be sorted before comparison.

Working with `Set<Integer>` would be wrong because it would Eliminate illegal duplicates.

Fixes #124.