### PR TITLE
[W07H02] remove tests that are trying to define undefined behaviour

### DIFF
--- a/w07h02/test/pgdp/security/TestBase.java
+++ b/w07h02/test/pgdp/security/TestBase.java
@@ -65,11 +65,6 @@ public abstract class TestBase {
     }
 
     @Test
-    void upShouldReturnFalseOnNullInput() {
-        assertFalse(sut.up(null));
-    }
-
-    @Test
     void upShouldReturnFalseOnEmptyInput() {
         assertFalse(sut.up(""));
     }

--- a/w07h02/test/pgdp/security/TrackTest.java
+++ b/w07h02/test/pgdp/security/TrackTest.java
@@ -253,21 +253,14 @@ public class TrackTest {
 
     void assertCreateLappedCarAt(int postAt, int capacity, List<Integer> expectedCalls) {
         assertLappedCarAt(true, postAt, capacity, expectedCalls);
-
-
     }
 
     void assertRemoveLappedCarAt(int postAt, int capacity, List<Integer> expectedCalls) {
         assertLappedCarAt(false, postAt, capacity, expectedCalls);
-
-
     }
 
     @Test
     void createLappedCarAtSmallArray() {
-        assertCreateLappedCarAt(0, 1, List.of(0, 0, 0, 0));
-        assertCreateLappedCarAt(1, 2, List.of(1, 0, 1, 0));
-        assertCreateLappedCarAt(1, 3, List.of(1, 2, 0, 1));
         assertCreateLappedCarAt(1, 4, List.of(1, 2, 3, 0));
     }
 
@@ -280,9 +273,6 @@ public class TrackTest {
 
     @Test
     void removeLappedCarAtSmallArray() {
-        assertRemoveLappedCarAt(0, 1, List.of(0, 0, 0, 0));
-        assertRemoveLappedCarAt(1, 2, List.of(1, 0, 1, 0));
-        assertRemoveLappedCarAt(1, 3, List.of(1, 2, 0, 1));
         assertRemoveLappedCarAt(1, 4, List.of(1, 2, 3, 0));
     }
 


### PR DESCRIPTION
* The behavior for tracks with size < 4 is not specified when creating/removing a lapped car. Therefore there shouldn't be any tests for this case. We can assume that the track size is always >= 4 if there are lapped cars involved ([confirmed](https://zulip.in.tum.de/#narrow/stream/1494-PGdP-W07H02/topic/Track.20L.C3.A4nge/near/832611)).
* The behavior of `up()`/`down()` for input `null` is not defined. We therefore shouldn't test. Input is guaranteed to be a valid String ([confirmed](https://zulip.in.tum.de/#narrow/stream/1494-PGdP-W07H02/topic/up.2Fdown.20type.20.3D.3D.20null/near/836835)).