### PR TITLE
[W07H02] Hard code expected strings in toString Tests

### DIFF
--- a/w07h02/test/pgdp/security/FinishPostTest.java
+++ b/w07h02/test/pgdp/security/FinishPostTest.java
@@ -21,15 +21,16 @@ public class FinishPostTest extends FlagPostTest {
     @Override
     @Test
     void correctToString() {
-        sut.up("red");
-        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵finish⎵post⎵is⎵in⎵level⎵%d⎵and⎵is⎵⎵waving⎵⎵%s".replace("⎵", " "), sut.getPostNumber(), sut.getLevel(), sut.getDepiction());
+        final var depiction = "red";
+        sut.up(depiction);
+        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵finish⎵post⎵is⎵in⎵level⎵4⎵and⎵is⎵⎵waving⎵⎵%s".replace("⎵", " "), sut.getPostNumber(), depiction);
         assertEquals(expected, sut.toString());
     }
 
     @Override
     @Test
     void correctToStringForLevelZero() {
-        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵finish⎵post⎵is⎵in⎵level⎵%d⎵and⎵is⎵⎵doing⎵nothing".replace("⎵", " "), sut.getPostNumber(), sut.getLevel());
+        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵finish⎵post⎵is⎵in⎵level⎵0⎵and⎵is⎵⎵doing⎵nothing".replace("⎵", " "), sut.getPostNumber());
         assertEquals(expected, sut.toString());
     }
 }

--- a/w07h02/test/pgdp/security/FlagPostTest.java
+++ b/w07h02/test/pgdp/security/FlagPostTest.java
@@ -122,7 +122,7 @@ public class FlagPostTest extends TestBase {
     @Override
     @Test
     void correctToStringForLevelZero() {
-        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵⎵flag⎵post⎵⎵is⎵in⎵level⎵%d⎵and⎵is⎵⎵doing⎵nothing".replace("⎵", " "), sut.getPostNumber(), sut.getLevel());
+        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵⎵flag⎵post⎵⎵is⎵in⎵level⎵0⎵and⎵is⎵⎵doing⎵nothing".replace("⎵", " "), sut.getPostNumber());
         assertEquals(expected, sut.toString());
     }
 
@@ -130,7 +130,7 @@ public class FlagPostTest extends TestBase {
     @Test
     void correctToString() {
         sut.up("end");
-        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵⎵flag⎵post⎵⎵is⎵in⎵level⎵%d⎵and⎵is⎵⎵waving⎵⎵%s".replace("⎵", " "), sut.getPostNumber(), sut.getLevel(), sut.getDepiction());
+        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵⎵flag⎵post⎵⎵is⎵in⎵level⎵5⎵and⎵is⎵⎵waving⎵⎵end".replace("⎵", " "), sut.getPostNumber());
         assertEquals(expected, sut.toString());
     }
 }

--- a/w07h02/test/pgdp/security/LightPanelTest.java
+++ b/w07h02/test/pgdp/security/LightPanelTest.java
@@ -49,15 +49,16 @@ public class LightPanelTest extends TestBase {
     @Test
     @Override
     void correctToStringForLevelZero() {
-        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵light⎵panel⎵is⎵in⎵level⎵%d⎵and⎵is⎵switched⎵off".replace("⎵", " "), sut.getPostNumber(), sut.getLevel());
+        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵light⎵panel⎵is⎵in⎵level⎵0⎵and⎵is⎵switched⎵off".replace("⎵", " "), sut.getPostNumber());
         assertEquals(expected, sut.toString());
     }
 
     @Test
     @Override
     void correctToString() {
-        sut.up("green");
-        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵light⎵panel⎵is⎵in⎵level⎵%d⎵and⎵is⎵blinking⎵%s".replace("⎵", " "), sut.getPostNumber(), sut.getLevel(), sut.getDepiction());
+        final var depiction = "green";
+        sut.up(depiction);
+        final var expected = String.format("Signal⎵post⎵%d⎵of⎵type⎵light⎵panel⎵is⎵in⎵level⎵1⎵and⎵is⎵blinking⎵%s".replace("⎵", " "), sut.getPostNumber(), depiction);
         assertEquals(expected, sut.toString());
     }
 


### PR DESCRIPTION
<!-- Danke, dass du deine Tests mit deinen Kommilitonen teilst. -->
<!-- Beschreibe doch kurz hier drin, was deine Tests überprüfen und ob du dir eventuell bei etwas unsicher bist. -->
<!-- Denk dran, dass deine Kommilitonen auch schon die Tests sehen, bevor dieser PR gemergt wird, pass also auf, was du an Code pusht! 
-->
Some people get weird error messages with the toString() tests, because their internal state points to the wrong level. To make this more clear, I replaced all calls to get the current level with the actual expected level.
<!-- Bitte nutzte ebenfalls als Prefix für den Titel der Pull Request die Woche und die Nr. der Hausaufgabe, z.B "[W02H02] Deinen Titel". Solltest an keiner Hausaufgabe eine Änderung genommen haben, nutze stattdessen [*] als Prefix.

Ebenfalls bitten wir dich darum, dass du nur an einer Hausaufgabe pro Pull Request Änderungen vornimmst. Solltest du Änderungen in mehreren Hausaufgaben vorgenommen haben, spalte bitte diese Änderungen in mehrere Pull Requests auf. -->
