### PR TITLE
[W08H01] Add test for usage of `values()` in `getValues()`

### DIFF
--- a/w08h01/test/pgdp/NoUsageOfValuesMethodTest.java
+++ b/w08h01/test/pgdp/NoUsageOfValuesMethodTest.java
@@ -21,7 +21,7 @@ public class NoUsageOfValuesMethodTest {
     // you if you have code in your solution that is not allowed.
     @DisplayName("Source code should not contain .values() method because they are not allowed in this exercise")
     @Test
-    public void testUsageOfLoops() throws IOException {
+    public void testUsageOfValuesMethod() throws IOException {
         String[] notAllowedRegExp = new String[] {
                 "\\.values\\(",
         };
@@ -52,7 +52,8 @@ public class NoUsageOfValuesMethodTest {
                     for (int i = 0; i < lines.length; i++) {
                         Matcher matcher = Pattern.compile(regExp).matcher(lines[i]);
                         assertFalse(matcher.find(),
-                                "You are not allowed to use loops in your solution! Found a loop in " + path);
+                                "You are not allowed to use .values() methods in your solution! Found a .values() method in "
+                                        + path);
                     }
                 }
             });


### PR DESCRIPTION
This test validates if you are using the `.values()` method your source code. Exceptions are when your using the method in `main()`, `toString()`, `toIntArray()`, `specialSort()` and `intersection()`.

The code is copied from the `LoopTest.java` from the W06H01 tests. However, this version now supports single line and block comments. So you could have `.values()` in your comments and the test would still pass 👍 