### PR TITLE
[W08H03] Add performance tests

### DIFF
--- a/w08h01/test/pgdp/NoUsageOfValuesMethodTest.java
+++ b/w08h01/test/pgdp/NoUsageOfValuesMethodTest.java
@@ -1,0 +1,220 @@
+package pgdp;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class NoUsageOfValuesMethodTest {
+    // Note: This test has a lot of false positives (e. g. using the not allowed
+    // code in helper methods for allowed methods). The test should just warn
+    // you if you have code in your solution that is not allowed.
+    @DisplayName("Source code should not contain .values() method because they are not allowed in this exercise")
+    @Test
+    public void testUsageOfValuesMethod() throws IOException {
+        String[] notAllowedRegExp = new String[] {
+                "\\.values\\(",
+        };
+
+        try (Stream<Path> sourceFiles = Files.find(Path.of("src"), 100,
+                (filePath, fileAttr) -> fileAttr.isRegularFile() && filePath.toString().endsWith(".java"))) {
+            sourceFiles.forEach(f -> {
+                String path = f.toString();
+
+                // Methods where everything is allowed.
+                String[] allowedMethods = new String[] {
+                        "public static void main(String[] args) {",
+                        "public static void main(String... args) {",
+                        "public static String toString(Collection<?> collection) {",
+                        "public static int[] toIntArray(Collection<Integer> collection) {",
+                        "public static <T> T[] generateGenericArray(Class<T> clazz, int length) {",
+                        "public static <T> T[] specialSort(Class<T> clazz, Collection<T> collection, Comparator<T> comparator) {",
+                        "public static <T> Collection<T> intersection(Collection<T>[] collections) {",
+                };
+
+                String file = readFile(path);
+                String fileWithoutComments = removeComments(file);
+                String filteredFile = removeMultipleMethods(fileWithoutComments, allowedMethods);
+
+                // Check if there is not allowed usage of code.
+                for (String regExp : notAllowedRegExp) {
+                    String[] lines = filteredFile.split("\n");
+                    for (int i = 0; i < lines.length; i++) {
+                        Matcher matcher = Pattern.compile(regExp).matcher(lines[i]);
+                        assertFalse(matcher.find(),
+                                "You are not allowed to use .values() methods in your solution! Found a .values() method in "
+                                        + path);
+                    }
+                }
+            });
+        }
+    }
+
+    private String removeMultipleMethods(String file, String[] methods) {
+        for (String method : methods) {
+            file = removeMethod(file, method);
+        }
+        return file;
+    }
+
+    /**
+     * Removes all comments from a file.
+     * 
+     * @param file The file as string.
+     * @return The file without comments.
+     */
+    private String removeComments(String file) {
+        file = removeSingleLineComments(file);
+        file = removeBlockComments(file);
+        return file;
+    }
+
+    /**
+     * Removes all single line comments from a file.
+     *
+     * Block comments are not removed.
+     *
+     * @param file
+     * @return
+     */
+    private String removeSingleLineComments(String file) {
+        String[] lines = file.split("\n");
+        String newFile = "";
+        for (String line : lines) {
+            if (!line.trim().startsWith("//")) {
+                newFile += line + "\n";
+            }
+        }
+        return newFile;
+    }
+
+    /**
+     * Removes all block comments from a file.
+     *
+     * Single line comments are not removed.
+     *
+     * @param file
+     * @return
+     */
+    private String removeBlockComments(String file) {
+        String[] lines = file.split("\n");
+        String newFile = "";
+        boolean inBlockComment = false;
+        for (String line : lines) {
+            if (line.contains("/*")) {
+                inBlockComment = true;
+            }
+            if (!inBlockComment) {
+                newFile += line + "\n";
+            }
+            if (line.contains("*/")) {
+                inBlockComment = false;
+            }
+        }
+        return newFile;
+    }
+
+    /**
+     * Removes a method from a file
+     * <p>
+     * The method goes through the file line by line and searches the name of
+     * the method. When the method is found, the method is searching for the
+     * closing bracket of the method. When the closing bracket is found, the
+     * method is removed.
+     *
+     * @param file   The file as string
+     * @param method The name of the method to remove
+     * @return
+     */
+    private String removeMethod(String file, String method) {
+        String[] lines = file.split("\n");
+        int start = -1;
+
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i].contains(method)) {
+                start = i;
+                break;
+            }
+        }
+
+        if (start == -1) {
+            // Could not find me
+            return file;
+        }
+
+        // When the method is found, we search for the closing bracket. However,
+        // we need to keep in mind that we can not search for the next closing
+        // bracket because this could be the closing bracket of a for loop or
+        // what ever.For this we use a stack. When we find a opening bracket, we
+        // push it to the stack. When we find a closing bracket, we pop the
+        // stack. When the stack is empty, we found the closing bracket of the
+        // method.
+        Stack<String> brackets = new Stack<String>();
+
+        int end = -1;
+        for (int i = start + 1; i < lines.length && end == -1; i++) {
+            String[] characters = lines[i].split("");
+            for (String c : characters) {
+                if (c.equals("{")) {
+                    brackets.push(c);
+                } else if (c.equals("}")) {
+                    if (brackets.isEmpty()) {
+                        // When the stack is empty, we know that we found the
+                        // matching closing bracket
+                        end = i;
+                        break;
+                    }
+                    brackets.pop();
+                }
+            }
+        }
+
+        if (end == -1) {
+            // Could not find end
+            return file;
+        }
+
+        // Build new file without the lines of the removed method.
+        String newFile = "";
+        for (int i = 0; i < lines.length; i++) {
+            if (i < start || i > end) {
+                newFile += lines[i] + "\n";
+            }
+        }
+
+        return newFile;
+    }
+
+    private String readFile(String path) {
+        try (BufferedReader br = new BufferedReader(new FileReader(path))) {
+            try {
+                StringBuilder sb = new StringBuilder();
+                String line = br.readLine();
+
+                while (line != null) {
+                    sb.append(line);
+                    sb.append(System.lineSeparator());
+                    line = br.readLine();
+                }
+                return sb.toString();
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
+                br.close();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/w08h03/test/pgdp/datastructures/PerformanceTest.java
+++ b/w08h03/test/pgdp/datastructures/PerformanceTest.java
@@ -1,0 +1,121 @@
+package pgdp.datastructures;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class PerformanceTest {
+
+	/*
+	 * The ÜL has declined to give us an order of magnitude on Zulip so I went with
+	 * one million nodes. This is surely enough, but it might even be too much. It
+	 * is unlikely but possible to have a valid solution and fail these performance
+	 * tests. If you like, you can change the variable NUMBER_OF_VALUES_IN_TREE and
+	 * try some lower values.
+	 * 
+	 * This test should absolutely pass for low values such as 1000 and only take a
+	 * few milliseconds to do so.
+	 */
+	@Test
+	@DisplayName("Read 1M values")
+	public void testPerformance1M() {
+		int NUMBER_OF_VALUES_IN_TREE = (int) 1e6;
+
+		List<Integer> values = IntStream.range(0, NUMBER_OF_VALUES_IN_TREE).boxed().collect(Collectors.toList());
+		List<Integer> solution = IntStream.range(0, NUMBER_OF_VALUES_IN_TREE).boxed().collect(Collectors.toList());
+		Collections.shuffle(values);
+
+		QuarternarySearchTree<Integer> n = new QuarternarySearchTree<Integer>();
+		for (Integer i : values) {
+			n.insert(i);
+		}
+
+		ArrayList<Integer> actual = new ArrayList<>();
+
+		System.out.println(
+				"Keep in mind the RAM usage and its differences during iteration is not a terribly useful metric here:");
+		long memUsageMBBefore = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())
+				/ (1024 * 1024);
+		System.out.println("Memory usage before iteration: " + memUsageMBBefore + "MB");
+
+		long startTime = System.nanoTime();
+
+		for (Integer r : n) {
+
+			if (r.intValue() == 0) {
+				long memUsageMB = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())
+						/ (1024 * 1024);
+				System.out.println("Memory usage at the start of iteration: " + memUsageMB + "MB");
+			} else if (r.intValue() == NUMBER_OF_VALUES_IN_TREE - 1) {
+				long memUsageMB = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())
+						/ (1024 * 1024);
+				System.out.println("Memory usage at the end of iteration: " + memUsageMB + "MB");
+			}
+
+			actual.add(r);
+		}
+
+		long endTime = System.nanoTime();
+
+		System.out.println("Time taken to read " + NUMBER_OF_VALUES_IN_TREE + " nodes from a Tree of "
+				+ NUMBER_OF_VALUES_IN_TREE + ": "
+				+ (endTime - startTime) / 1000000 + "ms");
+
+		assertEquals(solution, actual);
+	}
+
+	/*
+	 * The same disclaimer is valid here as in the testPerformance1M test above.
+	 * 
+	 * Here you can again change the two variables NUMBER_OF_VALUES_IN_TREE and
+	 * NUMBER_OF_VALUES_TO_ITERATE_OVER to see if it passes with lower values.
+	 * 
+	 * This is much faster for lazy implementations than it is for non-lazy ones but
+	 * should easily be solvable for both.
+	 * 
+	 * A non-lazy implementation will take roughly as long here as for the
+	 * "Read 1M values" test.
+	 */
+	@Test
+	@DisplayName("1M values but only read first 1k")
+	public void testPerformance1MRead1k() {
+		int NUMBER_OF_VALUES_IN_TREE = (int) 1e6;
+		int NUMBER_OF_VALUES_TO_ITERATE_OVER = (int) 1000;
+
+		List<Integer> values = IntStream.range(0, NUMBER_OF_VALUES_IN_TREE).boxed().collect(Collectors.toList());
+		List<Integer> solution = IntStream.range(0, NUMBER_OF_VALUES_TO_ITERATE_OVER).boxed()
+				.collect(Collectors.toList());
+		Collections.shuffle(values);
+
+		QuarternarySearchTree<Integer> n = new QuarternarySearchTree<Integer>();
+		for (Integer i : values) {
+			n.insert(i);
+		}
+
+		ArrayList<Integer> actual = new ArrayList<>();
+
+		long startTime = System.nanoTime();
+
+		for (Integer r : n) {
+			if (r.intValue() >= NUMBER_OF_VALUES_TO_ITERATE_OVER) {
+				break;
+			}
+			actual.add(r);
+		}
+
+		long endTime = System.nanoTime();
+
+		System.out.println("Time taken to read " + NUMBER_OF_VALUES_TO_ITERATE_OVER + " nodes from a Tree of "
+				+ NUMBER_OF_VALUES_IN_TREE + ": "
+				+ (endTime - startTime) / 1000000 + "ms");
+
+		assertEquals(solution, actual);
+	}
+}

--- a/w08h03/test/pgdp/datastructures/PerformanceTest.java
+++ b/w08h03/test/pgdp/datastructures/PerformanceTest.java
@@ -8,10 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class PerformanceTest {
+	final int seed = 69420;
 
 	/*
 	 * The ÜL has declined to give us an order of magnitude on Zulip so I went with
@@ -30,7 +32,7 @@ public class PerformanceTest {
 
 		List<Integer> values = IntStream.range(0, NUMBER_OF_VALUES_IN_TREE).boxed().collect(Collectors.toList());
 		List<Integer> solution = IntStream.range(0, NUMBER_OF_VALUES_IN_TREE).boxed().collect(Collectors.toList());
-		Collections.shuffle(values);
+		Collections.shuffle(values, new Random(seed));
 
 		QuarternarySearchTree<Integer> n = new QuarternarySearchTree<Integer>();
 		for (Integer i : values) {
@@ -92,7 +94,7 @@ public class PerformanceTest {
 		List<Integer> values = IntStream.range(0, NUMBER_OF_VALUES_IN_TREE).boxed().collect(Collectors.toList());
 		List<Integer> solution = IntStream.range(0, NUMBER_OF_VALUES_TO_ITERATE_OVER).boxed()
 				.collect(Collectors.toList());
-		Collections.shuffle(values);
+		Collections.shuffle(values, new Random(seed));
 
 		QuarternarySearchTree<Integer> n = new QuarternarySearchTree<Integer>();
 		for (Integer i : values) {

--- a/w08h03/test/pgdp/datastructures/UnitTest.java
+++ b/w08h03/test/pgdp/datastructures/UnitTest.java
@@ -13,8 +13,6 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import javax.xml.stream.events.StartDocument;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -40,90 +38,6 @@ public class UnitTest {
 
 		assertEquals(expected.length, position,
 				"Invalid Iteration Count. Expected [" + expected.length + "] got [" + position + "]");
-	}
-
-	@Test
-	@DisplayName("Read 1M nodes")
-	public void testPerformance1M() {
-		int amountOfValues = (int) 1e6;
-
-		List<Integer> values = IntStream.range(0, amountOfValues).boxed().collect(Collectors.toList());
-		List<Integer> solution = IntStream.range(0, amountOfValues).boxed().collect(Collectors.toList());
-		Collections.shuffle(values);
-
-		QuarternarySearchTree<Integer> n = new QuarternarySearchTree<Integer>();
-		for (Integer i : values) {
-			n.insert(i);
-		}
-
-		ArrayList<Integer> actual = new ArrayList<>();
-
-		System.out.println("Keep in mind the RAM usage and its differences during iteration is not a terribly useful metric here:");
-		long memUsageMBBefore = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())
-				/ (1024 * 1024);
-		System.out.println("Memory usage before iteration: " + memUsageMBBefore + "MB");
-
-		long startTime = System.nanoTime();
-
-		for (Integer r : n) {
-
-			if (r.intValue() == 0) {
-				long memUsageMB = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())
-						/ (1024 * 1024);
-				System.out.println("Memory usage at the start of iteration: " + memUsageMB + "MB");
-			} else if (r.intValue() == amountOfValues - 1) {
-				long memUsageMB = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())
-						/ (1024 * 1024);
-				System.out.println("Memory usage at the end of iteration: " + memUsageMB + "MB");
-			}
-
-			actual.add(r);
-		}
-
-		long endTime = System.nanoTime();
-
-		System.out.println("Time taken to read " + amountOfValues + " nodes from a Tree of " + amountOfValues + ": "
-				+ (endTime - startTime) / 1000000 + "ms");
-
-		assertEquals(solution, actual);
-	}
-
-	/*
-	 * This is much faster for lazy implementations than it is for non-lazy ones but should easily be solvable for both.
-	 * A non-lazy implementation will take roughly as long here as for the "Read 1M nodes" test.
-	 */
-	@Test
-	@DisplayName("1M nodes but only read first 1k")
-	public void testPerformance1MRead1k() {
-		int amountOfValues = (int) 1e6;
-		int readValues = (int) 1000;
-
-		List<Integer> values = IntStream.range(0, amountOfValues).boxed().collect(Collectors.toList());
-		List<Integer> solution = IntStream.range(0, readValues).boxed().collect(Collectors.toList());
-		Collections.shuffle(values);
-
-		QuarternarySearchTree<Integer> n = new QuarternarySearchTree<Integer>();
-		for (Integer i : values) {
-			n.insert(i);
-		}
-
-		ArrayList<Integer> actual = new ArrayList<>();
-
-		long startTime = System.nanoTime();
-
-		for (Integer r : n) {
-			if (r.intValue() >= readValues) {
-				break;
-			}
-			actual.add(r);
-		}
-
-		long endTime = System.nanoTime();
-
-		System.out.println("Time taken to read " + readValues + " nodes from a Tree of " + amountOfValues + ": "
-				+ (endTime - startTime) / 1000000 + "ms");
-
-		assertEquals(solution, actual);
 	}
 
 	@Test

--- a/w08h03/test/pgdp/datastructures/UnitTest.java
+++ b/w08h03/test/pgdp/datastructures/UnitTest.java
@@ -4,13 +4,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/w08h03/test/pgdp/datastructures/UnitTest.java
+++ b/w08h03/test/pgdp/datastructures/UnitTest.java
@@ -1,23 +1,17 @@
 package pgdp.datastructures;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.Random;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnitTest {
 	static int seed = 69420;
@@ -90,6 +84,37 @@ public class UnitTest {
 	}
 
 	@Test
+	@DisplayName("should work with two iterators in parallel")
+	public void parallelIteratorsTest() {
+		QuarternarySearchTree<Integer> t = new QuarternarySearchTree<>();
+
+		Random random = new Random();
+		int[] values = IntStream.range(0, 20).map(__ -> random.nextInt()).toArray();
+		int[] expected = Arrays.copyOf(values, values.length);
+		Arrays.sort(expected);
+
+		for (var v : values) t.insert(v);
+
+		var iter1 = t.iterator();
+		var iter2 = t.iterator();
+
+		for (int i = 0; i < values.length; i++) {
+			int exp = expected[i];
+			int element1 = iter1.next();
+			int element2 = iter2.next();
+
+			assertEquals(exp, element1, "Invalid Output at position [" + i + "] in Iterator 1: Expected [" + exp
+					+ "], got [" + element1 + "]");
+
+			assertEquals(exp, element2, "Invalid Output at position [" + i + "] in Iterator 2: Expected [" + exp
+					+ "], got [" + element2 + "]");
+		}
+
+		assertFalse(iter1.hasNext(), "Iterator 1 should be empty.");
+		assertFalse(iter2.hasNext(), "Iterator 2 should be empty.");
+	}
+
+	@Test
 	@DisplayName("should iterate over a non-numeric graph")
 	public void stringTest() {
 		IntStream.range(0, 10).forEach(i -> {
@@ -121,7 +146,7 @@ public class UnitTest {
 		for (int j = 0; j <= i; j++) {
 			treeIt.next();
 			if(j == i) {
-				Assertions.assertFalse(treeIt.hasNext());
+				assertFalse(treeIt.hasNext());
 			} else {
 				Assertions.assertTrue(treeIt.hasNext());
 			}
@@ -131,6 +156,6 @@ public class UnitTest {
 	@Test
 	@DisplayName("should return the correct value for hasNext() on empty tree")
 	public void hasNextTestEmpty() {
-		Assertions.assertFalse((new QuarternarySearchTree<Integer>()).iterator().hasNext());
+		assertFalse((new QuarternarySearchTree<Integer>()).iterator().hasNext());
 	}
 }

--- a/w08h03/test/pgdp/datastructures/UnitTest.java
+++ b/w08h03/test/pgdp/datastructures/UnitTest.java
@@ -4,9 +4,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -34,6 +38,54 @@ public class UnitTest {
 
 		assertEquals(expected.length, position,
 				"Invalid Iteration Count. Expected [" + expected.length + "] got [" + position + "]");
+	}
+
+	@Test
+	@DisplayName("Performance. Lazy is fast here.")
+	public void testPerformanceForLazy() {
+		int amountOfValues = 10000;
+		int readValues = 100;
+
+		List<Integer> values = IntStream.range(0, amountOfValues).boxed().collect(Collectors.toList());
+		List<Integer> solution = IntStream.range(0, readValues).boxed().collect(Collectors.toList());
+		Collections.shuffle(values);
+
+		QuarternarySearchTree<Integer> n = new QuarternarySearchTree<Integer>();
+		for (Integer i : values) {
+			n.insert(i);
+		}
+		ArrayList<Integer> actual = new ArrayList<>();
+		for (Integer r : n) {
+			if(r.intValue() >= readValues){
+				break;
+			}
+			actual.add(r);
+		}
+		assertEquals(solution, actual);
+	}
+
+	@Test
+	@DisplayName("Test RAM usage for 10k nodes")
+	public void testRAMUsage10k() {
+		int amountOfValues = 10000;
+		int readValues = 100;
+
+		List<Integer> values = IntStream.range(0, amountOfValues).boxed().collect(Collectors.toList());
+		List<Integer> solution = IntStream.range(0, readValues).boxed().collect(Collectors.toList());
+		Collections.shuffle(values);
+
+		QuarternarySearchTree<Integer> n = new QuarternarySearchTree<Integer>();
+		for (Integer i : values) {
+			n.insert(i);
+		}
+		ArrayList<Integer> actual = new ArrayList<>();
+		for (Integer r : n) {
+			if(r.intValue() >= readValues){
+				break;
+			}
+			actual.add(r);
+		}
+		assertEquals(solution, actual);
 	}
 
 	@Test
@@ -69,14 +121,6 @@ public class UnitTest {
 		});
 	}
 
-	// private static int seedDifference = 0;
-	// private static Stream<Arguments> testArray() {
-	// 	// TODO improve this
-	// 	return Stream.generate(() -> {
-	// 		return arguments((new Random(seed + seedDifference++)).ints(seedDifference, 0, Integer.MAX_VALUE).toArray());
-	// 	}).limit(10);
-	// }
-
 	private String generateString(Random rnd) {
 		StringBuilder s = new StringBuilder();
 		rnd.ints(rnd.nextInt(100), 97, 122).mapToObj(i -> (char) i).forEach(s::append);
@@ -93,7 +137,8 @@ public class UnitTest {
 		int[] expected = Arrays.copyOf(values, values.length);
 		Arrays.sort(expected);
 
-		for (var v : values) t.insert(v);
+		for (var v : values)
+			t.insert(v);
 
 		var iter1 = t.iterator();
 		var iter2 = t.iterator();
@@ -145,7 +190,7 @@ public class UnitTest {
 		Assertions.assertTrue(treeIt.hasNext());
 		for (int j = 0; j <= i; j++) {
 			treeIt.next();
-			if(j == i) {
+			if (j == i) {
 				assertFalse(treeIt.hasNext());
 			} else {
 				Assertions.assertTrue(treeIt.hasNext());

--- a/w08h03/test/pgdp/datastructures/UnitTest.java
+++ b/w08h03/test/pgdp/datastructures/UnitTest.java
@@ -44,7 +44,7 @@ public class UnitTest {
 
 	@Test
 	@DisplayName("Read 1M nodes")
-	public void testPerformance10k() {
+	public void testPerformance1M() {
 		int amountOfValues = (int) 1e6;
 
 		List<Integer> values = IntStream.range(0, amountOfValues).boxed().collect(Collectors.toList());

--- a/w08h03/test/pgdp/datastructures/UnitTest.java
+++ b/w08h03/test/pgdp/datastructures/UnitTest.java
@@ -88,9 +88,13 @@ public class UnitTest {
 		assertEquals(solution, actual);
 	}
 
+	/*
+	 * This is much faster for lazy implementations than it is for non-lazy ones but should easily be solvable for both.
+	 * A non-lazy implementation will take roughly as long here as for the "Read 1M nodes" test.
+	 */
 	@Test
-	@DisplayName("1M nodes but only read first 1k. Lazy is fast here.")
-	public void testPerformanceForLazy() {
+	@DisplayName("1M nodes but only read first 1k")
+	public void testPerformance1MRead1k() {
 		int amountOfValues = (int) 1e6;
 		int readValues = (int) 1000;
 

--- a/w08h03/test/pgdp/datastructures/UnitTest.java
+++ b/w08h03/test/pgdp/datastructures/UnitTest.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -83,7 +85,7 @@ public class UnitTest {
 
 	private String generateString(Random rnd) {
 		StringBuilder s = new StringBuilder();
-		rnd.ints(rnd.nextInt(100), 97, 122).mapToObj(i -> (char) i).forEach(c -> s.append(c));
+		rnd.ints(rnd.nextInt(100), 97, 122).mapToObj(i -> (char) i).forEach(s::append);
 		return s.toString();
 	}
 
@@ -101,5 +103,34 @@ public class UnitTest {
 
 			testArray(args);
 		});
+	}
+
+	@Test
+	@DisplayName("should return the correct values for hasNext() on full tree")
+	public void hasNextTest() {
+		QuarternarySearchTree<Integer> tree = new QuarternarySearchTree<>();
+		int i = 100;
+
+		// fill the tree with a bunch of numbers
+		for (int j = 0; j <= i; j++) {
+			tree.insert(j);
+		}
+
+		var treeIt = tree.iterator();
+		Assertions.assertTrue(treeIt.hasNext());
+		for (int j = 0; j <= i; j++) {
+			treeIt.next();
+			if(j == i) {
+				Assertions.assertFalse(treeIt.hasNext());
+			} else {
+				Assertions.assertTrue(treeIt.hasNext());
+			}
+		}
+	}
+
+	@Test
+	@DisplayName("should return the correct value for hasNext() on empty tree")
+	public void hasNextTestEmpty() {
+		Assertions.assertFalse((new QuarternarySearchTree<Integer>()).iterator().hasNext());
 	}
 }


### PR DESCRIPTION
This adds 2 tests. Both create trees with 1 million nodes.
The first test then iterates through all of them again, times it, and checks the output for correctness.
Additionally, it prints RAM usage during some steps of the way but includes a disclaimer that this isn't a terribly useful number.
The second test iterates through only the first 1k elements, times it, and checks the output for correctness.
The latter will perform much better with lazy solutions.

I also removed a commented-out code block.

🐧