### PR TITLE
[W08H03] Add a test with a tree where a node returns `[null, a, null,  b]` for `getChildren()`

### DIFF
--- a/w08h03/test/pgdp/datastructures/UnitTest.java
+++ b/w08h03/test/pgdp/datastructures/UnitTest.java
@@ -49,6 +49,15 @@ public class UnitTest {
 	}
 
 	@Test
+	@DisplayName("should iterate over graph where a node can have 'null, a, null b' as children")
+	public void testChildrenContainingNull() {
+		// The value 14 and 15 are the children of the node 13. However, returns
+		// `getChildren` of node 13 in the following order: [null, 14, null,
+		// 15]. Therefore, your implementation should handle this case. 
+		testArray(new Integer[] { 18, 8, 4, 12, 1, 5, 9, 13, 3, 7, 11, 15, 2, 6, 10, 14 });
+	}
+
+	@Test
 	@DisplayName("should iterate over a graph of one repeat element")
 	public void oneElementTest() {
 		testArray(new Integer[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 });


### PR DESCRIPTION
<img width="709" alt="image" src="https://user-images.githubusercontent.com/24459435/208141425-207b3379-8fc7-485d-bb60-b630e8675abb.png">

With this tree the node 13 returns `[null, 14, null, 15]` when calling `getChildren()`. My first implementation passed all other tests but failed this one. Therefore, I'm adding it to our tests.