### PR TITLE
[W08H02] test(TaskFunctionBehaviorTest): Add strict equals comparison

### DIFF
--- a/w08h02/test/pgdp/pools/TaskBehaviorTest.java
+++ b/w08h02/test/pgdp/pools/TaskBehaviorTest.java
@@ -232,14 +232,15 @@ public class TaskBehaviorTest {
     @DisplayName("equals() should return false for identical input and overwritten hashCode method")
     void equalsDifferentUnderlyingHashCodeMethod() {
         var func1 = new TaskFunction<Integer, Integer>(INC);
-        var func2 = new TaskFunction<Integer, Integer>(INC) {
+        var func2 = new TaskFunction<Integer, Integer>(INC);
+
+        var task1 = new Task<>(1, func1);
+        var task2 = new Task<>(1, func2) {
             @Override
             public int hashCode() {
-                return "I'm Afraid I Can't Do That, Dave.".hashCode();
+                return task1.hashCode();
             }
         };
-        var task1 = new Task<>(1, func1);
-        var task2 = new Task<>(1, func2);
 
         assertNotEquals(task1, task2, "equals should yield false for task with different hashCode method (subclassed)");
     }

--- a/w08h02/test/pgdp/pools/TaskBehaviorTest.java
+++ b/w08h02/test/pgdp/pools/TaskBehaviorTest.java
@@ -217,7 +217,7 @@ public class TaskBehaviorTest {
     }
 
     @Test
-    @DisplayName("equals() should return false for identical input and different subclassed function")
+    @DisplayName("equals() should return false for identical input and different subclassed method")
     void equalsDifferentUnderlyingSubclassedFunction() {
         var func1 = new TaskFunction<Integer, Integer>(INC);
         var func2 = new TaskFunction<Integer, Integer>(INC) {
@@ -225,7 +225,23 @@ public class TaskBehaviorTest {
         var task1 = new Task<>(1, func1);
         var task2 = new Task<>(1, func2);
 
-        assertNotEquals(task1, task2, "equals should yield false for task with different underlying functions (subclassed)");
+        assertNotEquals(task1, task2, "equals should yield false for task with different underlying methods (subclassed)");
+    }
+
+    @Test
+    @DisplayName("equals() should return false for identical input and overwritten hashCode method")
+    void equalsDifferentUnderlyingHashCodeMethod() {
+        var func1 = new TaskFunction<Integer, Integer>(INC);
+        var func2 = new TaskFunction<Integer, Integer>(INC) {
+            @Override
+            public int hashCode() {
+                return "I'm Afraid I Can't Do That, Dave.".hashCode();
+            }
+        };
+        var task1 = new Task<>(1, func1);
+        var task2 = new Task<>(1, func2);
+
+        assertNotEquals(task1, task2, "equals should yield false for task with different hashCode method (subclassed)");
     }
 
 }

--- a/w08h02/test/pgdp/pools/TaskBehaviorTest.java
+++ b/w08h02/test/pgdp/pools/TaskBehaviorTest.java
@@ -216,4 +216,16 @@ public class TaskBehaviorTest {
         assertNotEquals(task1, task2, "equals should yield false for task with different underlying functions");
     }
 
+    @Test
+    @DisplayName("equals() should return false for identical input and different subclassed function")
+    void equalsDifferentUnderlyingSubclassedFunction() {
+        var func1 = new TaskFunction<Integer, Integer>(INC);
+        var func2 = new TaskFunction<Integer, Integer>(INC) {
+        };
+        var task1 = new Task<>(1, func1);
+        var task2 = new Task<>(1, func2);
+
+        assertNotEquals(task1, task2, "equals should yield false for task with different underlying functions (subclassed)");
+    }
+
 }

--- a/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
+++ b/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
@@ -159,7 +159,6 @@ public class TaskFunctionBehaviorTest {
         }
 
         var func2 = new TaskFunction<Integer, Integer>(SQUARE) {
-            @Override
             // In case TaskFunction::equals uses getID() which changes symmetry of equals
             public int getID() {
                 return idOfFunc1;

--- a/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
+++ b/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
@@ -144,34 +144,17 @@ public class TaskFunctionBehaviorTest {
     }
 
     @Test
-    @DisplayName("equals() should return true for identical input and manipulated subclassed function with the same IDs")
+    @DisplayName("equals() should return false for identical input and manipulated subclassed function")
     void equalsUnderlyingSubclassedFunction() {
         var func1 = new TaskFunction<Integer, Integer>(SQUARE);
         var func2 = new TaskFunction<Integer, Integer>(SQUARE) {
+            @Override
+            public int getID() {
+                return func1.getID();
+            }
         };
 
-        /* As stated: Equals and hashCode should only be dependent on the underlying ID.
-         *
-         * By setting the ID of the anonymous subclass to the ID of func1, we
-         * emulate a method overwrite where ID and hashCode is overwritten in the
-         * anonymous class.
-         *
-         * We can't implement ID and hashCode in func2, because it would expose illegal code.
-         *
-         * The goal of this test is to see if the equals method uses a Class::getClass comparison
-         * thus locking Class::equals to instances of the same class.
-         */
-        Class<?> anon = func2.getClass().getSuperclass();
-        try {
-            Field field = anon.getDeclaredField("ID");
-            field.setAccessible(true);
-            field.set(func2, func1.getID());
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException("Could not find field ID in TaskFunction: " + e);
-        }
-
-
-        assertEquals(func1, func2, "equals should yield true for task with manipulated underlying functions (subclassed) with the same IDs");
+        assertFalse(func1.equals(func2), "equals should yield false for task with manipulated underlying getID()");
     }
 
 }

--- a/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
+++ b/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
@@ -150,18 +150,16 @@ public class TaskFunctionBehaviorTest {
     void equalsUnderlyingSubclassedFunction() {
         var func1 = new TaskFunction<Integer, Integer>(SQUARE);
         var func2 = new TaskFunction<Integer, Integer>(SQUARE) {
-            private final int ID = func1.getID();
-
             @Override
             // In case TaskFunction::equals uses getID() which changes symmetry of equals
             public int getID() {
-                return ID;
+                return func1.getID();
             }
 
             @Override
             // In case TaskFunction::equals uses hashCode() which changes symmetry of equals
             public int hashCode() {
-                return Objects.hashCode(ID);
+                return func1.hashCode();
             }
         };
 

--- a/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
+++ b/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
@@ -9,7 +9,6 @@ import static pgdp.pools.FunctionLib.SQUARE;
 import static pgdp.pools.FunctionLib.SUM_OF_HALFS;
 
 import java.lang.reflect.Field;
-import java.util.Objects;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;

--- a/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
+++ b/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
@@ -9,6 +9,8 @@ import static pgdp.pools.FunctionLib.SQUARE;
 import static pgdp.pools.FunctionLib.SUM_OF_HALFS;
 
 import java.lang.reflect.Field;
+import java.util.Objects;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -148,13 +150,22 @@ public class TaskFunctionBehaviorTest {
     void equalsUnderlyingSubclassedFunction() {
         var func1 = new TaskFunction<Integer, Integer>(SQUARE);
         var func2 = new TaskFunction<Integer, Integer>(SQUARE) {
+            private final int ID = func1.getID();
+
             @Override
+            // In case TaskFunction::equals uses getID() which changes symmetry of equals
             public int getID() {
-                return func1.getID();
+                return ID;
+            }
+
+            @Override
+            // In case TaskFunction::equals uses hashCode() which changes symmetry of equals
+            public int hashCode() {
+                return Objects.hashCode(ID);
             }
         };
 
-        assertFalse(func1.equals(func2), "equals should yield false for task with manipulated underlying getID()");
+        assertFalse(func1.equals(func2), "equals should yield false for task with overwritten methods");
     }
 
 }

--- a/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
+++ b/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
@@ -146,12 +146,23 @@ public class TaskFunctionBehaviorTest {
     @Test
     @DisplayName("equals() should return false for identical input and manipulated subclassed function")
     void equalsUnderlyingSubclassedFunction() {
+        final int idOfFunc1;
         var func1 = new TaskFunction<Integer, Integer>(SQUARE);
+
+        Class obj = func1.getClass();
+        try {
+            Field field = obj.getDeclaredField("ID");
+            field.setAccessible(true);
+            idOfFunc1 = field.getInt(func1);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("ID not found in TaskFunction: " + e);
+        }
+
         var func2 = new TaskFunction<Integer, Integer>(SQUARE) {
             @Override
             // In case TaskFunction::equals uses getID() which changes symmetry of equals
             public int getID() {
-                return func1.getID();
+                return idOfFunc1;
             }
 
             @Override

--- a/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
+++ b/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
@@ -143,4 +143,35 @@ public class TaskFunctionBehaviorTest {
         assertFalse(task1.equals(task2), "equals should yield false for two different TaskFunction instances");
     }
 
+    @Test
+    @DisplayName("equals() should return true for identical input and manipulated subclassed function with the same IDs")
+    void equalsUnderlyingSubclassedFunction() {
+        var func1 = new TaskFunction<Integer, Integer>(SQUARE);
+        var func2 = new TaskFunction<Integer, Integer>(SQUARE) {
+        };
+
+        /* As stated: Equals and hashCode should only be dependent on the underlying ID.
+         *
+         * By setting the ID of the anonymous subclass to the ID of func1, we
+         * emulate a method overwrite where ID and hashCode is overwritten in the
+         * anonymous class.
+         *
+         * We can't implement ID and hashCode in func2, because it would expose illegal code.
+         *
+         * The goal of this test is to see if the equals method uses a Class::getClass comparison
+         * thus locking Class::equals to instances of the same class.
+         */
+        Class<?> anon = func2.getClass().getSuperclass();
+        try {
+            Field field = anon.getDeclaredField("ID");
+            field.setAccessible(true);
+            field.set(func2, func1.getID());
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Could not find field ID in TaskFunction: " + e);
+        }
+
+
+        assertEquals(func1, func2, "equals should yield true for task with manipulated underlying functions (subclassed) with the same IDs");
+    }
+
 }

--- a/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
+++ b/w08h02/test/pgdp/pools/TaskFunctionBehaviorTest.java
@@ -9,7 +9,6 @@ import static pgdp.pools.FunctionLib.SQUARE;
 import static pgdp.pools.FunctionLib.SUM_OF_HALFS;
 
 import java.lang.reflect.Field;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
> Überschriebene Methoden hashCode und equals, die jeweils nur von ID abhängig sein sollen.

The goal of the first test is to see if TaskFunction::equals uses a Class::getClass comparison thus locking Class::equals to instances of the same class. TaskFunction::equals may only be dependent on ID, in case of altering a different instance of TaskFunction to the same value (e.g. by a method overwrite) it should yield true.

The second test is trivial as we are not overwriting any methods in the subclass, we could still produce an undefined behaviour in flawed implementations that can't handle subclasses.