### PR TITLE
[W09H01] Add Comments for Test 2

### DIFF
--- a/w09h01/test/pgdp/pingutrip/ReadWayPointsTest.java
+++ b/w09h01/test/pgdp/pingutrip/ReadWayPointsTest.java
@@ -22,7 +22,14 @@ public class ReadWayPointsTest {
             assertEquals(expected[i], actual[i], "The value at index " + i + " is wrong");
         }
     }
-
+    
+    /* Comments:
+    Mac OS may throw IOException lazyly if the directory does not exist.
+    So if you have dealt with IOException on Mac, you still might encounter it.
+    However, this JUnit test will not be executed in Artemis.
+    So if you are sure that you have dealt with IOException, you can ignore this test.
+    (for MacOS) By: BSLK11
+    */
     @Test
     void testReturnsEmptyStreamOnError() {
         Stream<WayPoint> points = PinguTrip.readWayPoints("");


### PR DESCRIPTION
Mac OS may throw IOException lazily if the directory does not exist. So if you have dealt with IOException on Mac, you still might encounter it. However, this JUnit test will not be executed in Artemis. So if you are sure that you have dealt with IOException, you can ignore this test. (for MacOS)

<!-- Danke, dass du deine Tests mit deinen Kommilitonen teilst. -->
<!-- Beschreibe doch kurz hier drin, was deine Tests überprüfen und ob du dir eventuell bei etwas unsicher bist. -->
<!-- Denk dran, dass deine Kommilitonen auch schon die Tests sehen, bevor dieser PR gemergt wird, pass also auf, was du an Code pusht! 
-->

<!-- Bitte nutzte ebenfalls als Prefix für den Titel der Pull Request die Woche und die Nr. der Hausaufgabe, z.B "[W02H02] Deinen Titel". Solltest an keiner Hausaufgabe eine Änderung genommen haben, nutze stattdessen [*] als Prefix.

Ebenfalls bitten wir dich darum, dass du nur an einer Hausaufgabe pro Pull Request Änderungen vornimmst. Solltest du Änderungen in mehreren Hausaufgaben vorgenommen haben, spalte bitte diese Änderungen in mehrere Pull Requests auf. -->
