### PR TITLE
[W09H01] Do not use an empty string for file path for the `readWayPoints` method test

### DIFF
--- a/w09h01/test/pgdp/pingutrip/ReadWayPointsTest.java
+++ b/w09h01/test/pgdp/pingutrip/ReadWayPointsTest.java
@@ -21,7 +21,7 @@ public class ReadWayPointsTest {
 
     @Test
     void testReturnsEmptyStreamOnError() {
-        Stream<WayPoint> points = PinguTrip.readWayPoints("");
+        Stream<WayPoint> points = PinguTrip.readWayPoints("not-existing-path");
         assertEquals(0, points.count(), "The stream should be empty");
     }
 }


### PR DESCRIPTION
When passing an empty String, Java throws an `IOException`. However, this is not covered by the Artemis tests is not required to get the points. Because this led to problems (see #192), I'm going to change it to a path that is not existing. 
