### PR TITLE
[W09H02] Add tests for `worstDelayedTrain`

### DIFF
--- a/w09h02/test/pgdp/trains/processing/OfficialExampleTests.java
+++ b/w09h02/test/pgdp/trains/processing/OfficialExampleTests.java
@@ -99,11 +99,6 @@ class OfficialExampleTests {
     }
 
     @Test
-    void worstDelayedTrain() {
-        assertEquals(trainConnections.get(2), DataProcessing.worstDelayedTrain(trainConnections.stream()));
-    }
-
-    @Test
     void percentOfKindStopsWithKindRegular() {
         assertEquals(85.71428571428571, DataProcessing.percentOfKindStops(trainConnections.stream(), TrainStop.Kind.REGULAR), EPSILON);
     }

--- a/w09h02/test/pgdp/trains/processing/WorstDelayedTrainTest.java
+++ b/w09h02/test/pgdp/trains/processing/WorstDelayedTrainTest.java
@@ -16,6 +16,7 @@ public class WorstDelayedTrainTest {
     // The example from the `main` method.
     @Test
     void testExample() {
+        // The list of connections from the example.
         List<TrainConnection> trainConnections = List.of(
                 new TrainConnection("ICE 2", "ICE", "2", "DB", List.of(
                         new TrainStop(Station.MUENCHEN_HBF,
@@ -56,6 +57,7 @@ public class WorstDelayedTrainTest {
 
     @Test
     void testEmpty() {
+        // A list of no train connections.
         List<TrainConnection> trainConnections = List.of();
 
         TrainConnection worstDelayedTrain = DataProcessing.worstDelayedTrain(trainConnections.stream());
@@ -66,6 +68,7 @@ public class WorstDelayedTrainTest {
 
     @Test
     void testMultipleTrainsWithSameWorstDelay() {
+        // A list of train connections where 2 trains have the same worst delay.
         List<TrainConnection> trainConnections = List.of(
                 new TrainConnection("ICE 1", "ICE", "1", "DB", List.of(
                         new TrainStop(Station.MUENCHEN_HBF,

--- a/w09h02/test/pgdp/trains/processing/WorstDelayedTrainTest.java
+++ b/w09h02/test/pgdp/trains/processing/WorstDelayedTrainTest.java
@@ -1,0 +1,142 @@
+package pgdp.trains.processing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import pgdp.trains.connections.Station;
+import pgdp.trains.connections.TrainConnection;
+import pgdp.trains.connections.TrainStop;
+
+public class WorstDelayedTrainTest {
+    // The example from the `main` method.
+    @Test
+    void testExample() {
+        List<TrainConnection> trainConnections = List.of(
+                new TrainConnection("ICE 2", "ICE", "2", "DB", List.of(
+                        new TrainStop(Station.MUENCHEN_HBF,
+                                LocalDateTime.of(2022, 12, 1, 11, 0),
+                                LocalDateTime.of(2022, 12, 1, 11, 0),
+                                TrainStop.Kind.REGULAR),
+                        new TrainStop(Station.NUERNBERG_HBF,
+                                LocalDateTime.of(2022, 12, 1, 11, 30),
+                                LocalDateTime.of(2022, 12, 1, 12, 0),
+                                TrainStop.Kind.REGULAR))),
+                new TrainConnection("ICE 1", "ICE", "1", "DB", List.of(
+                        new TrainStop(Station.MUENCHEN_HBF,
+                                LocalDateTime.of(2022, 12, 1, 10, 0),
+                                LocalDateTime.of(2022, 12, 1, 10, 0),
+                                TrainStop.Kind.REGULAR),
+                        new TrainStop(Station.NUERNBERG_HBF,
+                                LocalDateTime.of(2022, 12, 1, 10, 30),
+                                LocalDateTime.of(2022, 12, 1, 10, 30),
+                                TrainStop.Kind.REGULAR))),
+                new TrainConnection("ICE 3", "ICE", "3", "DB", List.of(
+                        new TrainStop(Station.MUENCHEN_HBF,
+                                LocalDateTime.of(2022, 12, 1, 12, 0),
+                                LocalDateTime.of(2022, 12, 1, 12, 0),
+                                TrainStop.Kind.REGULAR),
+                        new TrainStop(Station.AUGSBURG_HBF,
+                                LocalDateTime.of(2022, 12, 1, 12, 20),
+                                LocalDateTime.of(2022, 12, 1, 13, 0),
+                                TrainStop.Kind.CANCELLED),
+                        new TrainStop(Station.NUERNBERG_HBF,
+                                LocalDateTime.of(2022, 12, 1, 13, 30),
+                                LocalDateTime.of(2022, 12, 1, 13, 30),
+                                TrainStop.Kind.REGULAR))));
+
+        TrainConnection worstDelayedTrain = DataProcessing.worstDelayedTrain(trainConnections.stream());
+
+        assertEquals(trainConnections.get(2), worstDelayedTrain);
+    }
+
+    @Test
+    void testEmpty() {
+        List<TrainConnection> trainConnections = List.of();
+
+        TrainConnection worstDelayedTrain = DataProcessing.worstDelayedTrain(trainConnections.stream());
+
+        // When no connections are provided the method should return null.
+        assertEquals(null, worstDelayedTrain);
+    }
+
+    @Test
+    void testMultipleTrainsWithSameWorstDelay() {
+        List<TrainConnection> trainConnections = List.of(
+                new TrainConnection("ICE 1", "ICE", "1", "DB", List.of(
+                        new TrainStop(Station.MUENCHEN_HBF,
+                                LocalDateTime.of(2022, 12, 1, 10, 0),
+                                LocalDateTime.of(2022, 12, 1, 10, 0),
+                                TrainStop.Kind.REGULAR),
+                        new TrainStop(Station.NUERNBERG_HBF,
+                                LocalDateTime.of(2022, 12, 1, 10, 30),
+                                LocalDateTime.of(2022, 12, 1, 10, 30),
+                                TrainStop.Kind.REGULAR))),
+                new TrainConnection("ICE 2", "ICE", "2", "DB", List.of(
+                        new TrainStop(Station.MUENCHEN_HBF,
+                                LocalDateTime.of(2022, 12, 1, 11, 0),
+                                LocalDateTime.of(2022, 12, 1, 11, 0),
+                                TrainStop.Kind.REGULAR),
+                        new TrainStop(Station.NUERNBERG_HBF,
+                                LocalDateTime.of(2022, 12, 1, 11, 30),
+                                LocalDateTime.of(2022, 12, 1, 12, 0),
+                                TrainStop.Kind.REGULAR))),
+                new TrainConnection("ICE 3", "ICE", "3", "DB", List.of(
+                        new TrainStop(Station.MUENCHEN_HBF,
+                                LocalDateTime.of(2022, 12, 1, 12, 0),
+                                LocalDateTime.of(2022, 12, 1, 12, 0),
+                                TrainStop.Kind.REGULAR),
+                        new TrainStop(Station.NUERNBERG_HBF,
+                                LocalDateTime.of(2022, 12, 1, 12, 30),
+                                LocalDateTime.of(2022, 12, 1, 13, 0),
+                                TrainStop.Kind.REGULAR))));
+
+        TrainConnection worstDelayedTrain = DataProcessing.worstDelayedTrain(trainConnections.stream());
+
+        // Tests if worstDelayedTrain is one of the trains with the worst delay.
+        assertTrue(worstDelayedTrain.equals(trainConnections.get(1))
+                || worstDelayedTrain.equals(trainConnections.get(2)));
+    }
+
+    @Test
+    void testNoDelay() {
+        // A list of train connections with no delay.
+        List<TrainConnection> trainConnections = List.of(
+                new TrainConnection("ICE 1", "ICE", "1", "DB", List.of(
+                        new TrainStop(Station.MUENCHEN_HBF,
+                                LocalDateTime.of(2022, 12, 1, 10, 0),
+                                LocalDateTime.of(2022, 12, 1, 10, 0),
+                                TrainStop.Kind.REGULAR),
+                        new TrainStop(Station.NUERNBERG_HBF,
+                                LocalDateTime.of(2022, 12, 1, 10, 30),
+                                LocalDateTime.of(2022, 12, 1, 10, 30),
+                                TrainStop.Kind.REGULAR))),
+                new TrainConnection("ICE 2", "ICE", "2", "DB", List.of(
+                        new TrainStop(Station.MUENCHEN_HBF,
+                                LocalDateTime.of(2022, 12, 1, 11, 0),
+                                LocalDateTime.of(2022, 12, 1, 11, 0),
+                                TrainStop.Kind.REGULAR),
+                        new TrainStop(Station.NUERNBERG_HBF,
+                                LocalDateTime.of(2022, 12, 1, 11, 30),
+                                LocalDateTime.of(2022, 12, 1, 11, 30),
+                                TrainStop.Kind.REGULAR))),
+                new TrainConnection("ICE 3", "ICE", "3", "DB", List.of(
+                        new TrainStop(Station.MUENCHEN_HBF,
+                                LocalDateTime.of(2022, 12, 1, 12, 0),
+                                LocalDateTime.of(2022, 12, 1, 12, 0),
+                                TrainStop.Kind.REGULAR),
+                        new TrainStop(Station.NUERNBERG_HBF,
+                                LocalDateTime.of(2022, 12, 1, 12, 30),
+                                LocalDateTime.of(2022, 12, 1, 12, 30),
+                                TrainStop.Kind.REGULAR))));
+        
+        TrainConnection worstDelayedTrain = DataProcessing.worstDelayedTrain(trainConnections.stream());
+
+        // Tests that worstDelayedTrain is one of the connections
+        assertTrue(trainConnections.contains(worstDelayedTrain));
+    }
+}


### PR DESCRIPTION
* Moves the example test from `OfficialExampleTests.java` into a separate file `WorstDelayedTrainTest.java`
* Adds a test when the stream of connections is empty => should return `null`
* Adds a test when there are multiple connections with same worst delay => return any of the worst delayed connections
* Adds a test when there are no delayed connections => return any of the connections