### PR TITLE
[W09H02] Add more tests for `delayComparedToTravelTimeTest`

### DIFF
--- a/w09h02/test/pgdp/trains/processing/DelayComparedToTravelTimeTest.java
+++ b/w09h02/test/pgdp/trains/processing/DelayComparedToTravelTimeTest.java
@@ -2,8 +2,15 @@ package pgdp.trains.processing;
 
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
+
+import pgdp.trains.connections.Station;
+import pgdp.trains.connections.TrainConnection;
+import pgdp.trains.connections.TrainStop;
 import pgdp.trains.processing.utils.JSONParser;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -32,11 +39,53 @@ public class DelayComparedToTravelTimeTest {
     final JSONObject manipulated = DelayComparedToTravelTimeTest.manipulateSTR29();
 
     final Map<String, Double> result = DataProcessing.delayComparedToTotalTravelTimeByTransport(Stream.of(
-        JSONParser.getTrainConnectionFromJSON(manipulated)
-    ));
+        JSONParser.getTrainConnectionFromJSON(manipulated)));
 
     final double expected = 0.0;
 
     assertEquals(expected, result.get("STR"), "Result must not be NaN");
+  }
+
+  @Test
+  void testEmptyList() {
+    Stream<TrainConnection> trainConnections = Stream.empty();
+
+    final Map<String, Double> actual = DataProcessing.delayComparedToTotalTravelTimeByTransport(trainConnections);
+    final Map<String, Double> expected = Collections.emptyMap();
+
+    assertEquals(expected, actual, "Result must be empty");
+  }
+
+  @Test
+  void testTooEarlyTrainsShouldNotCompensateTheDelay() {
+    // A list of train connections where a train is too early
+    final Stream<TrainConnection> trainConnections = Stream.of(
+        new TrainConnection("ICE 1", "ICE", "1", "DB", List.of(
+            new TrainStop(Station.MUENCHEN_HBF,
+                LocalDateTime.of(2022, 12, 1, 10, 0),
+                LocalDateTime.of(2022, 12, 1, 10, 0),
+                TrainStop.Kind.REGULAR),
+            new TrainStop(Station.NUERNBERG_HBF,
+                LocalDateTime.of(2022, 12, 1, 17, 00),
+                // 1 hour too early
+                LocalDateTime.of(2022, 12, 1, 16, 00),
+                TrainStop.Kind.REGULAR))),
+        new TrainConnection("ICE 2", "ICE", "2", "DB", List.of(
+            new TrainStop(Station.MUENCHEN_HBF,
+                LocalDateTime.of(2022, 12, 1, 10, 0),
+                LocalDateTime.of(2022, 12, 1, 10, 0),
+                TrainStop.Kind.REGULAR),
+            new TrainStop(Station.NUERNBERG_HBF,
+                LocalDateTime.of(2022, 12, 1, 13, 0),
+                // 1 hour delay
+                LocalDateTime.of(2022, 12, 1, 14, 0),
+                TrainStop.Kind.REGULAR))));
+
+    // Source:
+    // https://zulip.in.tum.de/#narrow/stream/1504-PGdP-W09H02/topic/.E2.9C.94.20Zug.20kommt.20zu.20fr.C3.BCh.3F/near/880712
+    final Map<String, Double> expected = Map.of("ICE", 9.090909090909092);
+    final Map<String, Double> actual = DataProcessing.delayComparedToTotalTravelTimeByTransport(trainConnections);
+
+    assertEquals(expected, actual);
   }
 }


### PR DESCRIPTION
* Adds a test where the list of train connections is empty
* Adds a test where a train is too early => this should not change the amount of delay 