### PR TITLE
[W09H02] Add tests for `averageDelayByHour`

### DIFF
--- a/w09h02/test/pgdp/trains/processing/AverageDelayByHourTest.java
+++ b/w09h02/test/pgdp/trains/processing/AverageDelayByHourTest.java
@@ -1,0 +1,77 @@
+package pgdp.trains.processing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import pgdp.trains.connections.Station;
+import pgdp.trains.connections.TrainConnection;
+import pgdp.trains.connections.TrainStop;
+
+public class AverageDelayByHourTest {
+    // Example train connections from the `main` method in
+    // `DataProcessing.java`.
+    final List<TrainConnection> exampleTrainConnections = List.of(
+            new TrainConnection("ICE 2", "ICE", "2", "DB", List.of(
+                    new TrainStop(Station.MUENCHEN_HBF,
+                            LocalDateTime.of(2022, 12, 1, 11, 0),
+                            LocalDateTime.of(2022, 12, 1, 11, 0),
+                            TrainStop.Kind.REGULAR),
+                    new TrainStop(Station.NUERNBERG_HBF,
+                            LocalDateTime.of(2022, 12, 1, 11, 30),
+                            LocalDateTime.of(2022, 12, 1, 12, 0),
+                            TrainStop.Kind.REGULAR))),
+            new TrainConnection("ICE 1", "ICE", "1", "DB", List.of(
+                    new TrainStop(Station.MUENCHEN_HBF,
+                            LocalDateTime.of(2022, 12, 1, 10, 0),
+                            LocalDateTime.of(2022, 12, 1, 10, 0),
+                            TrainStop.Kind.REGULAR),
+                    new TrainStop(Station.NUERNBERG_HBF,
+                            LocalDateTime.of(2022, 12, 1, 10, 30),
+                            LocalDateTime.of(2022, 12, 1, 10, 30),
+                            TrainStop.Kind.REGULAR))),
+            new TrainConnection("ICE 3", "ICE", "3", "DB", List.of(
+                    new TrainStop(Station.MUENCHEN_HBF,
+                            LocalDateTime.of(2022, 12, 1, 12, 0),
+                            LocalDateTime.of(2022, 12, 1, 12, 0),
+                            TrainStop.Kind.REGULAR),
+                    new TrainStop(Station.AUGSBURG_HBF,
+                            LocalDateTime.of(2022, 12, 1, 12, 20),
+                            LocalDateTime.of(2022, 12, 1, 13, 0),
+                            TrainStop.Kind.CANCELLED),
+                    new TrainStop(Station.NUERNBERG_HBF,
+                            LocalDateTime.of(2022, 12, 1, 13, 30),
+                            LocalDateTime.of(2022, 12, 1, 13, 30),
+                            TrainStop.Kind.REGULAR))));
+
+    @Test
+    public void testExample() {
+        Stream<TrainConnection> trainConnections = exampleTrainConnections.stream();
+
+        Map<Integer, Double> expected = Map.of(
+                10, 0.0,
+                11, 0.0,
+                12, 15.0,
+                13, 20.0);
+        Map<Integer, Double> actual = DataProcessing.averageDelayByHour(trainConnections);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    @DisplayName("Should return an empty map if the stream is empty")
+    public void testEmpty() {
+        Stream<TrainConnection> trainConnections = Stream.empty();
+
+        Map<Integer, Double> expected = Map.of();
+        Map<Integer, Double> actual = DataProcessing.averageDelayByHour(trainConnections);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/w09h02/test/pgdp/trains/processing/OfficialExampleTests.java
+++ b/w09h02/test/pgdp/trains/processing/OfficialExampleTests.java
@@ -123,16 +123,4 @@ class OfficialExampleTests {
         Map<String, Double> actual = DataProcessing.delayComparedToTotalTravelTimeByTransport(trainConnections.stream());
         assertEquals(16.666666666666668, actual.get("ICE"),  EPSILON);
     }
-
-    @Test
-    void averageDelayByHour() {
-        Map<Integer, Double> actual = DataProcessing.averageDelayByHour(trainConnections.stream());
-        assertEquals(0.0, actual.get(10), EPSILON);
-        assertEquals(0.0, actual.get(11), EPSILON);
-        assertEquals(15.0, actual.get(12), EPSILON);
-        assertEquals(20.0, actual.get(13), EPSILON);
-        Set<Integer> expectedKeySet = Set.of(10, 11, 12, 13);
-        assertEquals(expectedKeySet, actual.keySet());
-    }
-
 }


### PR DESCRIPTION
* Moves the example test from `OfficialExampleTests.java` into a separate file `AverageDelayByHourTest.java`
* Add test when list of train connections is empty