### PR TITLE
[W10H03] replace depthTest with findTest

### DIFF
--- a/w10h03/test/pgdp/infinite/InfiniteTreeTest.java
+++ b/w10h03/test/pgdp/infinite/InfiniteTreeTest.java
@@ -1,10 +1,14 @@
 package pgdp.infinite;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class InfiniteTreeTest {
     @Test
@@ -21,12 +25,45 @@ public class InfiniteTreeTest {
         assertEquals("", node.getValue());
     }
 
-    @Test
-    public void depthTest() {
-        var tree = Trees.binaryCounter.get();
-        var optimizable = new OptimizableComparable<Integer>(8);
-        tree.withRoot(1);
-        assertEquals(8, tree.find(0, 5, optimizable));
+    @ParameterizedTest(name = "{5}")
+    @MethodSource
+    public void findTest(int from, int depth, int searchVal, int expected, String message, String name) {
+        var tree = Trees.countUpDown.get();
+        var optimizable = new OptimizableComparable<>(searchVal) {
+            @Override
+            public boolean process(Integer t) {
+                // System.out.printf("%s, %s, %s\n", expectedBest.compareTo(t), expectedBest, t);
+                if (expectedBest.equals(t)) {
+                    best = t;
+                    return true;
+                } else if (best == null) {
+                    best = 0;
+                } else if (Math.abs(expectedBest - t) < Math.abs(expectedBest - best)) {
+                    best = t;
+                }
+                return false;
+            }
+        };
+        assertEquals(expected, tree.find(from, depth, optimizable), message);
+    }
+
+    private static Stream<Arguments> findTest() {
+        return Stream.of(
+                arguments(
+                        0, 420, 420, 420,
+                        "Your implementation does not search deep enough!",
+                        "searches deep enough"
+                ),
+                arguments(
+                        0, 419, 420, 419,
+                        "Your implementation searches to deep!",
+                        "does not exceed search depth"
+                ),
+                arguments(-1, 420, 420, 0,
+                        "Your implementation should not have found anything but did not return the optimum value!",
+                        "returns optimum if no element found"
+                )
+        );
     }
 
     @Test

--- a/w10h03/test/pgdp/infinite/Lambdas.java
+++ b/w10h03/test/pgdp/infinite/Lambdas.java
@@ -43,4 +43,15 @@ public class Lambdas {
     public static final Function<String, Iterator<String>> libraryOfBabel = i -> {
         return "abcdefghijklmnopqrstuvwxyz".chars().mapToObj(j -> i + (char) j).iterator();
     };
+
+    /**
+     * @name Count up/down
+     * @description Generates tree with child [parent + 1] or [parent - 1] depending on the parents sign. Node with value 0 has children -1 and 1.
+     */
+    public static final Function<Integer, Iterator<Integer>> countUpDown = i -> {
+        if (i == 0)
+            return List.of(-1, 1).iterator();
+        else
+            return List.of(i < 0 ? i - 1 : i + 1).iterator();
+    };
 }

--- a/w10h03/test/pgdp/infinite/Trees.java
+++ b/w10h03/test/pgdp/infinite/Trees.java
@@ -17,4 +17,7 @@ public class Trees {
 
     public static Supplier<InfiniteTree<String>> libraryOfBabel = () ->
             new InfiniteTree<>(Lambdas.libraryOfBabel);
+
+    public static Supplier<InfiniteTree<Integer>> countUpDown = () ->
+            new InfiniteTree<>(Lambdas.countUpDown);
 }


### PR DESCRIPTION
It was not clear to me what `depthTest` actually does. I expected it to test if the implementation complies with the specified search depth which was not the case.

@Anatoly03 hope you're okay with this replacement.