### PR TITLE
[W10H02] Added memory usage to large example

### DIFF
--- a/w10h02/test/pgdp/teams/ArtemisTest.java
+++ b/w10h02/test/pgdp/teams/ArtemisTest.java
@@ -58,8 +58,10 @@ public class ArtemisTest {
 
         long timeAfter = System.currentTimeMillis();
         long elapsedTime = timeAfter - timeBefore;
+		long usedMemory = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1_000_000;
 
         System.out.printf("Test `computeOptimalLineupLarge()` took %sms to execute.\n", elapsedTime);
+		System.out.printf("Test `computeOptimalLineupLarge() took %sMB to execute.\n", usedMemory);
 
         var attackers = getField(lineup, "attackers");
         var defenders = getField(lineup, "defenders");


### PR DESCRIPTION
<!-- Thanks for sharing your tests with your fellow students. -->
<!-- Important: Before submitting your PR, please read our CONTRIBUTING.md file: https://github.com/MaximilianAnzinger/pgdp2223-tests/blob/main/CONTRIBUTING.md --->

Added message below time elapsed to show memory usage in MB of `computeOptimalLineupLarge()`.
It shouldn't be too large, but it allows to students to check how much RAM the large example used up, since it will cause tests to fail if it is too big.
See [this thread](https://zulip.in.tum.de/#narrow/stream/1519-PGdP-W10H02/topic/RAM.20Verbrauch/near/889633), as linked in the exercise.