### PR TITLE
[W10H01] Factor out zero length test in TrialOfTheDreams

### DIFF
--- a/w10h01/test/pgdp/trials/TrialOfTheDreamsTest.java
+++ b/w10h01/test/pgdp/trials/TrialOfTheDreamsTest.java
@@ -38,14 +38,19 @@ public class TrialOfTheDreamsTest {
             }
         });
     }
+    @Test
+    public void zeroLengthTest() {
+        byte[] combination = new byte[0];
+        Function<byte[], Boolean> lock = getLock(combination);
+        assert Arrays.equals(combination, TrialOfTheDreams.lockPick(lock));
+    }
 
     private static Stream<byte[]> combinationsTestValues () {
         return Stream.of(
-                    new byte[] {Byte.MAX_VALUE},
-                    new byte[] {-128, 127},
-                    new byte[] {25, 8, 30},
-                    new byte[] {25, -8, 30},
-                    new byte[0]
-                );
+                new byte[] {Byte.MAX_VALUE},
+                new byte[] {-128, 127},
+                new byte[] {25, 8, 30},
+                new byte[] {25, -8, 30}
+        );
     }
 }


### PR DESCRIPTION
Factor out the zero length test since it was always skipped in the previous tests.
