### PR TITLE
[W11H03] Fix many issues in W11H03

### DIFF
--- a/w11h03/test/pgdp/networking/HTTPTest.java
+++ b/w11h03/test/pgdp/networking/HTTPTest.java
@@ -217,7 +217,14 @@ public class HTTPTest {
                           "token_type": "irrelevant"
                         }""")
                 .respond(422, error);
-        assertNull(dataHandler.getContacts());
+        // See:
+
+        // See: https://zulip.in.tum.de/#narrow/stream/1525-PGdP-W11H03/topic/.E2.9C.94.20getContacts.28.29.20return.20type/near/902467
+        var contacts = dataHandler.getContacts();
+        OrBuilder
+                .assertThat(() -> assertNull(contacts))
+                .or(() -> assertEquals(Map.of(), contacts))
+                .run();
     }
 
     @Test
@@ -233,7 +240,12 @@ public class HTTPTest {
                         }""")
                 .respond(500,
                         "The stars! They’re all dying! There’ve been too many supernovae for it to be anything else! We’re next, do you understand?! Our sun! By Hearth’s name, we’re next!");
-        assertNull(dataHandler.getContacts());
+        // See: https://zulip.in.tum.de/#narrow/stream/1525-PGdP-W11H03/topic/.E2.9C.94.20getContacts.28.29.20return.20type/near/902467
+        var contacts = dataHandler.getContacts();
+        OrBuilder
+                .assertThat(() -> assertNull(contacts))
+                .or(() -> assertEquals(Map.of(), contacts))
+                .run();
     }
 
     @Test

--- a/w11h03/test/pgdp/networking/HTTPTest.java
+++ b/w11h03/test/pgdp/networking/HTTPTest.java
@@ -145,6 +145,8 @@ public class HTTPTest {
                     assertEquals("Bearer aG93IGxvbmcgYXJlIHlvdSBnb25uYSBrZWVwIGRvaW5nIHRoaXM=", authorization.get(0));
                 })
                 .respond(422, error);
+              
+        // See: https://zulip.in.tum.de/#narrow/stream/1525-PGdP-W11H03/topic/login.20Methode.20Attribute/near/909604
         assertFalse(dataHandler.login("Alfred", "Wagner"));
         assertNull(getField(dataHandler, "username"));
         assertNull(getField(dataHandler, "password"));
@@ -168,6 +170,7 @@ public class HTTPTest {
                     assertEquals("Bearer SSdtIG5vdCBoaWRpbmcgYW55dGhpbmcgaGVyZSB5J2tub3c=", authorization.get(0));
                 })
                 .respond(500, "Server's on fire");
+        // See: https://zulip.in.tum.de/#narrow/stream/1525-PGdP-W11H03/topic/login.20Methode.20Attribute/near/909604
         assertFalse(dataHandler.login("Alfred", "Wagner"));
         assertNull(getField(dataHandler, "username"));
         assertNull(getField(dataHandler, "password"));
@@ -217,7 +220,6 @@ public class HTTPTest {
                           "token_type": "irrelevant"
                         }""")
                 .respond(422, error);
-        // See:
 
         // See: https://zulip.in.tum.de/#narrow/stream/1525-PGdP-W11H03/topic/.E2.9C.94.20getContacts.28.29.20return.20type/near/902467
         var contacts = dataHandler.getContacts();
@@ -310,6 +312,7 @@ public class HTTPTest {
                 }""")
                 .respond(422, error);
         var result = dataHandler.getMessagesWithUser(06, 47, 0);
+        // See: https://zulip.in.tum.de/#narrow/stream/1525-PGdP-W11H03/topic/Was.20bei.20.60getMessagesWithUser.20.60.20!.3D.20200.20returnen.3F/near/909580
         OrBuilder
                 .assertThat(() -> assertNull(result))
                 .or(() -> assertEquals(List.of(), result))
@@ -328,6 +331,7 @@ public class HTTPTest {
                 }""")
                 .respond(500, "This song is new to me, but I am honored to be a part of it." );
         var result = dataHandler.getMessagesWithUser(06, 47, 0);
+        // See: https://zulip.in.tum.de/#narrow/stream/1525-PGdP-W11H03/topic/Was.20bei.20.60getMessagesWithUser.20.60.20!.3D.20200.20returnen.3F/near/909580
         OrBuilder
                 .assertThat(() -> assertNull(result))
                 .or(() -> assertEquals(List.of(), result))

--- a/w11h03/test/pgdp/networking/SocketTest.java
+++ b/w11h03/test/pgdp/networking/SocketTest.java
@@ -298,16 +298,12 @@ public class SocketTest {
             System.err.println("[WARNING] You will need to check if these values match by hand. Sorry :(");
         }
 
-
         // THIS REMOVES NULL-BYTES AT THE END OF THE STRING AND DELIBERATELY ALLOWS FOR A FAULTY REPRESENTATION OF THE MESSAGE
         // This is because the transformation into a byte-array is done incorrectly in the template
         // https://zulip.in.tum.de/#narrow/stream/1525-PGdP-W11H03/topic/StandardCharsets.2EUTF_8.2Eencode.28message.29.2Earray.28.29/near/909726
         String trimmedMessage = actualMessage.substring(0, message.length());
         assertTrue(actualMessage.substring(message.length()).matches("\\x00*"), "Message did not terminate with 0 or more null-bytes.");
         assertEquals(message, trimmedMessage, "Incorrect message content.");
-
-        // Assert end of output
-        assertEquals(actualMessageLength + 7, buffer.length, "Transferred bytes did not end after expected message.");
     }
 
     @Test

--- a/w11h03/test/pgdp/networking/SocketTest.java
+++ b/w11h03/test/pgdp/networking/SocketTest.java
@@ -287,7 +287,7 @@ public class SocketTest {
         int actualMessageLength = actualMessage.length();
 
         // See below
-        if (actualLength[0] < 0x01 || actualLength[0] == 1 && actualLength[1] < 0x0D) {
+        if (actualLength[0] == 0x00 || actualLength[0] == 1 && actualLength[1] > 0 && actualLength[1] < 0x0D) {
             assertTrue(actualLength[1] >= 0x0D, "Message length too small. Expected (270 <= length).");
         }
         if (actualLength[0] != 0x01 || actualLength[1] != 0x0D) {

--- a/w11h03/test/pgdp/networking/SocketTest.java
+++ b/w11h03/test/pgdp/networking/SocketTest.java
@@ -311,8 +311,8 @@ public class SocketTest {
     @DisplayName("sendMessage() – huge")
     void testMessagesHuge() throws IOException, InterruptedException {
         // Ideally, we would use resources here, but that seems difficult with the current tests setup
-        String lipsum = Files.readString(Path.of("./test/pgdp/networking/lipsum.txt")).replace("\r", "");
-        String lipsumTruncated = Files.readString(Path.of("./test/pgdp/networking/lipsum_truncated.txt")).replace("\r", "");
+        String lipsum = Files.readString(Path.of("./test/pgdp/networking/lipsum.txt")).replaceAll("\\r\\n?", "\n");
+        String lipsumTruncated = Files.readString(Path.of("./test/pgdp/networking/lipsum_truncated.txt")).replaceAll("\\r\\n?", "\n");
         Thread connectThread = new Thread(this::connect);
         connectThread.start();
         Socket client = server.accept();

--- a/w11h03/test/pgdp/networking/SocketTest.java
+++ b/w11h03/test/pgdp/networking/SocketTest.java
@@ -292,18 +292,17 @@ public class SocketTest {
                 .run();
 
         String actualMessage = new String(buffer, StandardCharsets.UTF_8).substring(3);
-        int messageLength = actualMessage.length();
+        int actualMessageLength = actualMessage.length();
 
         // THIS REMOVES NULL-BYTES AT THE END OF THE STRING AND DELIBERATELY ALLOWS FOR A FAULTY REPRESENTATION OF THE MESSAGE
         // This is because the transformation into a byte-array is done incorrectly in the template
         // https://zulip.in.tum.de/#narrow/stream/1525-PGdP-W11H03/topic/StandardCharsets.2EUTF_8.2Eencode.28message.29.2Earray.28.29/near/909726
-        if (buffer.length == 294) {
-            actualMessage = actualMessage.replace("\00", "");
-        }
-        assertEquals(message, actualMessage, "Incorrect message content.");
+        String trimmedMessage = actualMessage.substring(0, message.length());
+        assertTrue(actualMessage.substring(message.length()).matches("\\x00*"), "Message did not terminate with 0 or more null-bytes.");
+        assertEquals(message, trimmedMessage, "Incorrect message content.");
 
         // Assert end of output
-        assertEquals(messageLength + 7, buffer.length, "Transferred bytes did not end after expected message.");
+        assertEquals(actualMessageLength + 7, buffer.length, "Transferred bytes did not end after expected message.");
     }
 
     @Test

--- a/w11h03/test/pgdp/networking/SocketTest.java
+++ b/w11h03/test/pgdp/networking/SocketTest.java
@@ -283,16 +283,21 @@ public class SocketTest {
         var buffer = getAllBytes(clientThread, client);
         assertEquals(0x01, buffer[0], "Incorrect first byte");
         var actualLength = copyOf(buffer, 1, 3, "Message length");
-
-        // See below
-        OrBuilder
-                .assertThat(() -> assertArrayEquals(new byte[]{0x01, 0x23}, actualLength))
-                .or(() -> assertArrayEquals(new byte[]{0x01, 0x0D}, actualLength))
-                .withMessage("Incorrect message length")
-                .run();
-
         String actualMessage = new String(buffer, StandardCharsets.UTF_8).substring(3);
         int actualMessageLength = actualMessage.length();
+
+        // See below
+        if (actualLength[0] < 0x01 || actualLength[0] == 1 && actualLength[1] < 0x0D) {
+            assertTrue(actualLength[1] >= 0x0D, "Message length too small. Expected (270 <= length).");
+        }
+        if (actualLength[0] != 0x01 || actualLength[1] != 0x0D) {
+            System.err.println("[WARNING] The length bytes of your message might be incorrect.");
+            System.err.println("[WARNING] Due to the restrictions placed on me by the Übungsleitung, I cannot dynamically check whether your message size actually matches.");
+            System.err.println("[WARNING] Messages may end with a series of null-bytes. How many bytes there are, and consequently, how long your message is, is dependent on your implementation and OS.");
+            System.err.println("[WARNING] Bytes received: " + Arrays.toString(actualLength) + ", Actual length: " + actualMessageLength);
+            System.err.println("[WARNING] You will need to check if these values match by hand. Sorry :(");
+        }
+
 
         // THIS REMOVES NULL-BYTES AT THE END OF THE STRING AND DELIBERATELY ALLOWS FOR A FAULTY REPRESENTATION OF THE MESSAGE
         // This is because the transformation into a byte-array is done incorrectly in the template


### PR DESCRIPTION
This pull-request fixes the following issues:
- `getContacts()` not being allowed to return an empty map
- `testMessageHuge()` output being different on Windows
- `testMessage()` not accepting an arbitrarily long message buffer
- Not providing reasons for many assertions (Added Zulip links)