### PR TITLE
[W11B01] fix getmaxFlow

### DIFF
--- a/w11b01/test/pgdp/pengusurvivors/ResidualGraphTest.java
+++ b/w11b01/test/pgdp/pengusurvivors/ResidualGraphTest.java
@@ -174,11 +174,11 @@ public class ResidualGraphTest {
         return Stream.of(
                 Arguments.of(
                         """
-                                a -> b (4/10);
-                                b -> c (2/6);
+                                a -> b (0/10);
+                                b -> c (0/6);
                                 """,
                         "a", "c",
-                        8
+                        6
                 )
         );
     }


### PR DESCRIPTION
Having different flow rates in a graph like `a -> b -> c` leads to miscalculated maximum flow because it is an invalid state.

An error of this nature lead to the calculated (and expected) flowrate being 8 instead of 6.